### PR TITLE
Disable randomly failing HA tests

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHAFileCreationMultipleNNFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHAFileCreationMultipleNNFailure.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.log4j.Level;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -49,6 +50,8 @@ import java.net.InetSocketAddress;
  *
  */
 
+@Ignore(value = "The design of this test needs to be reconsidered. " +
+    "It fails most of the times because of race conditions.")
 public class TestHAFileCreationMultipleNNFailure
     extends junit.framework.TestCase {
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHARead.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestHARead.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
 import org.apache.log4j.Level;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.DataOutputStream;
@@ -38,6 +39,8 @@ import java.net.ConnectException;
  * It also tests if the system can be made highly available for reads even if
  * the writer is down
  */
+@Ignore(value = "The design of this test needs to be reconsidered. " +
+    "It fails most of the times because of race conditions.")
 public class TestHARead extends junit.framework.TestCase {
 
   public static final Log LOG = LogFactory.getLog(TestHARead.class);


### PR DESCRIPTION
TestHARead and TestHAFileCreationMultipleNNFailure are randomly failing. Probably because of race conditions. The test will be disabled for now. A second issue for revising these test cases was created.