### PR TITLE
This commit adds a metadata log for HopsWorks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/HdfsStorageFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/HdfsStorageFactory.java
@@ -49,6 +49,7 @@ import io.hops.metadata.hdfs.dal.INodeDataAccess;
 import io.hops.metadata.hdfs.dal.InvalidateBlockDataAccess;
 import io.hops.metadata.hdfs.dal.LeaseDataAccess;
 import io.hops.metadata.hdfs.dal.LeasePathDataAccess;
+import io.hops.metadata.hdfs.dal.MetadataLogDataAccess;
 import io.hops.metadata.hdfs.dal.PendingBlockDataAccess;
 import io.hops.metadata.hdfs.dal.QuotaUpdateDataAccess;
 import io.hops.metadata.hdfs.dal.ReplicaDataAccess;
@@ -62,6 +63,7 @@ import io.hops.metadata.hdfs.entity.ExcessReplica;
 import io.hops.metadata.hdfs.entity.IndexedReplica;
 import io.hops.metadata.hdfs.entity.InvalidatedBlock;
 import io.hops.metadata.hdfs.entity.LeasePath;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.metadata.hdfs.entity.QuotaUpdate;
 import io.hops.metadata.hdfs.entity.UnderReplicatedBlock;
 import io.hops.transaction.EntityManager;
@@ -78,6 +80,7 @@ import io.hops.transaction.context.InvalidatedBlockContext;
 import io.hops.transaction.context.LeSnapshot;
 import io.hops.transaction.context.LeaseContext;
 import io.hops.transaction.context.LeasePathContext;
+import io.hops.transaction.context.MetadataLogContext;
 import io.hops.transaction.context.PendingBlockContext;
 import io.hops.transaction.context.QuotaUpdateContext;
 import io.hops.transaction.context.ReplicaContext;
@@ -280,6 +283,9 @@ public class HdfsStorageFactory {
         entityContexts.put(QuotaUpdate.class, new QuotaUpdateContext(
             (QuotaUpdateDataAccess) getDataAccess(
                 QuotaUpdateDataAccess.class)));
+        entityContexts.put(MetadataLogEntry.class, new MetadataLogContext(
+            (MetadataLogDataAccess) getDataAccess(MetadataLogDataAccess.class)
+        ));
 
         return entityContexts;
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/adaptor/INodeDALAdaptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/adaptor/INodeDALAdaptor.java
@@ -157,13 +157,11 @@ public class INodeDALAdaptor
       hopINode.setParentId(inode.getParentId());
       hopINode.setId(inode.getId());
 
-      if (inode instanceof INodeDirectory) {
+      if (inode.isDirectory()) {
         hopINode.setUnderConstruction(false);
-        hopINode.setDirWithQuota(false);
-      }
-      if (inode instanceof INodeDirectoryWithQuota) {
-        hopINode.setUnderConstruction(false);
-        hopINode.setDirWithQuota(true);
+        hopINode.setDirWithQuota(inode instanceof INodeDirectoryWithQuota ?
+            true : false);
+        hopINode.setMetaEnabled(((INodeDirectory) inode).isMetaEnabled());
       }
       if (inode instanceof INodeFile) {
         hopINode
@@ -181,6 +179,7 @@ public class INodeDALAdaptor
                   .getXferAddr());
         }
         hopINode.setGenerationStamp(((INodeFile) inode).getGenerationStamp());
+        hopINode.setSize(((INodeFile) inode).getSize());
       }
       if (inode instanceof INodeSymlink) {
         hopINode.setUnderConstruction(false);
@@ -222,6 +221,7 @@ public class INodeDALAdaptor
 
         inode.setAccessTimeNoPersistance(hopINode.getAccessTime());
         inode.setModificationTimeNoPersistance(hopINode.getModificationTime());
+        ((INodeDirectory) inode).setMetaEnabled(hopINode.isMetaEnabled());
       } else if (hopINode.getSymlink() != null) {
         inode = new INodeSymlink(hopINode.getSymlink(),
             hopINode.getModificationTime(), hopINode.getAccessTime(), ps);
@@ -242,8 +242,9 @@ public class INodeDALAdaptor
           inode = new INodeFile(ps, hopINode.getHeader(),
               hopINode.getModificationTime(), hopINode.getAccessTime());
         }
-        ((INodeFile) inode)
-            .setGenerationStampNoPersistence(hopINode.getGenerationStamp());
+        ((INodeFile) inode).setGenerationStampNoPersistence(
+            hopINode.getGenerationStamp());
+        ((INodeFile) inode).setSize(hopINode.getSize());
       }
       inode.setIdNoPersistance(hopINode.getId());
       inode.setLocalNameNoPersistance(hopINode.getName());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/context/INodeContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/context/INodeContext.java
@@ -28,6 +28,7 @@ import io.hops.transaction.lock.Lock;
 import io.hops.transaction.lock.TransactionLockTypes;
 import io.hops.transaction.lock.TransactionLocks;
 import org.apache.hadoop.hdfs.server.namenode.INode;
+import org.apache.hadoop.hdfs.server.namenode.INodeFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/context/MetadataLogContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/context/MetadataLogContext.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.transaction.context;
+
+import io.hops.exception.StorageException;
+import io.hops.exception.TransactionContextException;
+import io.hops.metadata.common.FinderType;
+import io.hops.metadata.hdfs.dal.MetadataLogDataAccess;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
+import io.hops.transaction.lock.TransactionLocks;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class MetadataLogContext
+    extends BaseEntityContext<MetadataLogContext.Key, MetadataLogEntry> {
+  private final MetadataLogDataAccess<MetadataLogEntry> dataAccess;
+  private Collection<MetadataLogEntry> existing = Collections.emptyList();
+
+  class Key {
+    private int datasetId;
+    private int inodeId;
+    private int logicTime;
+
+    public Key(int datasetId, int inodeId, int logicTime) {
+      this.datasetId = datasetId;
+      this.inodeId = inodeId;
+      this.logicTime = logicTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Key key = (Key) o;
+
+      if (datasetId != key.datasetId) {
+        return false;
+      }
+      if (inodeId != key.inodeId) {
+        return false;
+      }
+      return logicTime == key.logicTime;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = datasetId;
+      result = 31 * result + inodeId;
+      result = 31 * result + logicTime;
+      return result;
+    }
+  }
+
+  public MetadataLogContext(
+      MetadataLogDataAccess dataAccess) {
+    this.dataAccess = dataAccess;
+  }
+
+  @Override
+  public void add(MetadataLogEntry logEntry)
+      throws TransactionContextException {
+    Key key = getKey(logEntry);
+    while (get(key) != null) {
+      key.logicTime++;
+    }
+    logEntry.setLogicalTime(key.logicTime);
+    super.add(logEntry);
+  }
+
+  @Override
+  Key getKey(MetadataLogEntry metadataLogEntry) {
+    return new Key(metadataLogEntry.getDatasetId(),
+        metadataLogEntry.getInodeId(), metadataLogEntry.getLogicalTime());
+  }
+
+  @Override
+  public void prepare(TransactionLocks tlm)
+      throws TransactionContextException, StorageException {
+    for (MetadataLogEntry existingEntry : existing) {
+      MetadataLogEntry cached = get(getKey(existingEntry));
+      cached.incrementLogicalTime();
+    }
+    dataAccess.addAll(getAdded());
+  }
+
+  @Override
+  public Collection<MetadataLogEntry> findList(
+      FinderType<MetadataLogEntry> finder, Object... params)
+      throws TransactionContextException, StorageException {
+    MetadataLogEntry.Finder mFinder = (MetadataLogEntry.Finder) finder;
+    switch (mFinder) {
+      case ALL_CACHED:
+        return new ArrayList<MetadataLogEntry>(getAll());
+      case FETCH_EXISTING:
+        return fetchExisting((Collection<MetadataLogEntry>) params[0]);
+      default:
+        throw new RuntimeException(UNSUPPORTED_FINDER);
+    }
+  }
+
+  private Collection<MetadataLogEntry> fetchExisting(
+      Collection<MetadataLogEntry> toRead) throws StorageException {
+    existing = dataAccess.readExisting(toRead);
+    return existing;
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/handler/HDFSOperationType.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/handler/HDFSOperationType.java
@@ -32,6 +32,7 @@ public enum HDFSOperationType implements OperationType {
   CREATE_SYM_LINK,
   GET_PREFERRED_BLOCK_SIZE,
   SET_REPLICATION,
+  SET_META_ENABLED,
   START_FILE,
   RECOVER_LEASE,
   APPEND_FILE,
@@ -72,6 +73,7 @@ public enum HDFSOperationType implements OperationType {
   GET_EXCESS_BLOCKS_COUNT,
   SET_ROOT,
   GET_ROOT,
+  GET_METADATA_LOG_ENTRIES,
   //BlockManager
   FIND_AND_MARK_BLOCKS_AS_CORRUPT,
   PREPARE_PROCESS_REPORT,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -1676,6 +1676,25 @@ public class DFSClient implements java.io.Closeable {
     }
   }
 
+  public void setMetaEnabled(final String src, final boolean metaEnabled)
+      throws IOException {
+    try {
+      ClientActionHandler handler = new ClientActionHandler() {
+        @Override
+        public Object doAction(ClientProtocol namenode)
+            throws RemoteException, IOException {
+          namenode.setMetaEnabled(src, metaEnabled);
+          return null;
+        }
+      };
+      doClientActionWithRetry(handler, "setMetaEnabled");
+    } catch (RemoteException re) {
+      throw re.unwrapRemoteException(AccessControlException.class,
+          FileNotFoundException.class, SafeModeException.class,
+          UnresolvedPathException.class);
+    }
+  }
+
   /**
    * Rename file or directory.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -475,6 +475,12 @@ public class DistributedFileSystem extends FileSystem {
     statistics.incrementWriteOps(1);
     return dfs.setReplication(getPathName(src), replication);
   }
+
+  public void setMetaEnabled(Path src, boolean metaEnabled)
+      throws IOException {
+    statistics.incrementWriteOps(1);
+    dfs.setMetaEnabled(getPathName(src), metaEnabled);
+  }
   
   /**
    * Move blocks from srcs to trg

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
@@ -405,6 +405,11 @@ public interface ClientProtocol {
       FileNotFoundException, SafeModeException, UnresolvedLinkException,
       IOException;
 
+  @Idempotent
+  public void setMetaEnabled(String src, boolean metaEnabled)
+      throws AccessControlException, FileNotFoundException, SafeModeException,
+      UnresolvedLinkException, IOException;
+
   /**
    * Set permissions for an existing file/directory.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -218,6 +218,11 @@ public class ClientNamenodeProtocolServerSideTranslatorPB
       VOID_CHANGECONF_RESPONSE =
       ClientNamenodeProtocolProtos.ChangeConfResponseProto.newBuilder().build();
 
+  private static final ClientNamenodeProtocolProtos.SetMetaEnabledResponseProto
+      VOID_SET_META_ENABLED_RESPONSE =
+      ClientNamenodeProtocolProtos.SetMetaEnabledResponseProto.newBuilder()
+          .build();
+
   /**
    * Constructor
    *
@@ -363,6 +368,19 @@ public class ClientNamenodeProtocolServerSideTranslatorPB
     } catch (IOException e) {
       throw new ServiceException(e);
     }
+  }
+
+  @Override
+  public ClientNamenodeProtocolProtos.SetMetaEnabledResponseProto setMetaEnabled(
+      RpcController controller,
+      ClientNamenodeProtocolProtos.SetMetaEnabledRequestProto req)
+      throws ServiceException {
+    try {
+      server.setMetaEnabled(req.getSrc(), req.getMetaEnabled());
+    } catch (IOException e) {
+      throw new ServiceException(e);
+    }
+    return VOID_SET_META_ENABLED_RESPONSE;
   }
 
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -300,6 +300,20 @@ public class ClientNamenodeProtocolTranslatorPB
   }
 
   @Override
+  public void setMetaEnabled(String src, boolean metaEnabled)
+      throws AccessControlException, FileNotFoundException, SafeModeException,
+      UnresolvedLinkException, IOException {
+    ClientNamenodeProtocolProtos.SetMetaEnabledRequestProto req =
+        ClientNamenodeProtocolProtos.SetMetaEnabledRequestProto.newBuilder()
+            .setSrc(src).setMetaEnabled(metaEnabled).build();
+    try {
+      rpcProxy.setMetaEnabled(null, req);
+    } catch (ServiceException e) {
+      throw ProtobufHelper.getRemoteException(e);
+    }
+  }
+
+  @Override
   public void setPermission(String src, FsPermission permission)
       throws AccessControlException, FileNotFoundException, SafeModeException,
       UnresolvedLinkException, IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirectory.java
@@ -23,9 +23,12 @@ import io.hops.exception.StorageException;
 import io.hops.exception.TransactionContextException;
 import io.hops.memcache.PathMemcache;
 import io.hops.metadata.HdfsStorageFactory;
+import io.hops.metadata.hdfs.dal.AccessTimeLogDataAccess;
 import io.hops.metadata.hdfs.dal.INodeAttributesDataAccess;
 import io.hops.metadata.hdfs.dal.INodeDataAccess;
+import io.hops.metadata.hdfs.entity.AccessTimeLogEntry;
 import io.hops.metadata.hdfs.entity.INodeCandidatePrimaryKey;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.metadata.hdfs.entity.QuotaUpdate;
 import io.hops.transaction.EntityManager;
 import io.hops.transaction.context.HdfsTransactionContextMaintenanceCmds;
@@ -62,6 +65,7 @@ import org.apache.hadoop.hdfs.server.blockmanagement.BlockManager;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants.BlockUCState;
 import org.apache.hadoop.hdfs.util.ByteArray;
+import org.apache.hadoop.security.AccessControlException;
 
 import java.io.Closeable;
 import java.io.FileNotFoundException;
@@ -341,6 +345,8 @@ public class FSDirectory implements Closeable {
               file.getBlocks().length +
               " blocks is persisted to the file system");
     }
+
+    file.logMetadataEvent(MetadataLogEntry.Operation.ADD);
   }
 
   /**
@@ -2098,6 +2104,7 @@ public class FSDirectory implements Closeable {
     INode removedNode = null;
     if (forRename) {
       removedNode = pathComponents[pos];
+      removedNode.logMetadataEvent(MetadataLogEntry.Operation.DELETE);
     } else {
       removedNode = ((INodeDirectory) pathComponents[pos - 1])
           .removeChild(pathComponents[pos]);
@@ -2150,6 +2157,7 @@ public class FSDirectory implements Closeable {
     INode removedNode = null;
     if (forRename) {
       removedNode = pathComponents[pos];
+      removedNode.logMetadataEvent(MetadataLogEntry.Operation.DELETE);
     } else {
       removedNode = ((INodeDirectory) pathComponents[pos - 1])
           .removeChild(pathComponents[pos]);
@@ -2463,20 +2471,22 @@ public class FSDirectory implements Closeable {
    * log.
    */
   void setTimes(String src, INode inode, long mtime, long atime, boolean force)
-      throws StorageException, TransactionContextException {
+      throws StorageException, TransactionContextException,
+      AccessControlException {
     unprotectedSetTimes(src, inode, mtime, atime, force);
   }
 
   boolean unprotectedSetTimes(String src, long mtime, long atime, boolean force)
       throws UnresolvedLinkException, StorageException,
-      TransactionContextException {
+      TransactionContextException, AccessControlException {
     INode inode = getINode(src);
     return unprotectedSetTimes(src, inode, mtime, atime, force);
   }
 
   private boolean unprotectedSetTimes(String src, INode inode, long mtime,
       long atime, boolean force)
-      throws StorageException, TransactionContextException {
+      throws StorageException, TransactionContextException,
+      AccessControlException {
     boolean status = false;
     if (mtime != -1) {
       inode.setModificationTimeForce(mtime);
@@ -2747,5 +2757,4 @@ public class FSDirectory implements Closeable {
     }
     return clone;
   }
-
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -25,6 +25,7 @@ import io.hops.common.IDsMonitor;
 import io.hops.common.INodeUtil;
 import io.hops.erasure_coding.Codec;
 import io.hops.erasure_coding.ErasureCodingManager;
+import io.hops.exception.StorageCallPreventedException;
 import io.hops.exception.StorageException;
 import io.hops.exception.TransactionContextException;
 import io.hops.memcache.PathMemcache;
@@ -34,12 +35,17 @@ import io.hops.metadata.hdfs.dal.BlockChecksumDataAccess;
 import io.hops.metadata.hdfs.dal.EncodingStatusDataAccess;
 import io.hops.metadata.hdfs.dal.INodeAttributesDataAccess;
 import io.hops.metadata.hdfs.dal.INodeDataAccess;
+import io.hops.metadata.hdfs.dal.MetadataLogDataAccess;
 import io.hops.metadata.hdfs.dal.SafeBlocksDataAccess;
+import io.hops.metadata.hdfs.dal.SizeLogDataAccess;
 import io.hops.metadata.hdfs.entity.BlockChecksum;
 import io.hops.metadata.hdfs.entity.EncodingPolicy;
 import io.hops.metadata.hdfs.entity.EncodingStatus;
 import io.hops.metadata.hdfs.entity.INodeIdentifier;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.metadata.hdfs.entity.ProjectedINode;
+import io.hops.metadata.hdfs.entity.SizeLogEntry;
+import io.hops.metadata.ndb.NdbStorageFactory;
 import io.hops.transaction.EntityManager;
 import io.hops.transaction.handler.EncodingStatusOperationType;
 import io.hops.transaction.handler.HDFSOperationType;
@@ -1419,6 +1425,72 @@ public class FSNamesystem
       logAuditEvent(true, "setReplication", src);
     }
     return isFile;
+  }
+
+  void setMetaEnabled(final String src, final boolean metaEnabled)
+      throws IOException {
+    try {
+      INode[] inodes = lockSubtree(src);
+      INode inode = inodes[inodes.length - 1];
+      final AbstractFileTree.FileTree fileTree = new AbstractFileTree.FileTree(
+          FSNamesystem.this, inode.getId());
+      fileTree.buildUp();
+      new HopsTransactionalRequestHandler(HDFSOperationType.SET_META_ENABLED,
+          src) {
+        @Override
+        public void acquireLock(TransactionLocks locks) throws IOException {
+          LockFactory lf = getInstance();
+          locks.add(lf.getINodeLock(nameNode, INodeLockType.WRITE,
+              INodeResolveType.PATH, true, true, src));
+        }
+
+        @Override
+        public Object performTask() throws IOException {
+          try {
+            logMetadataEvents(fileTree, MetadataLogEntry.Operation.ADD);
+            setMetaEnabledInt(src, metaEnabled);
+          } catch (AccessControlException e) {
+            logAuditEvent(false, "setMetaEnabled", src);
+            throw e;
+          }
+          return null;
+        }
+      }.handle(this);
+    } finally {
+      unlockSubtree(src);
+    }
+  }
+
+  private void setMetaEnabledInt(final String src, final boolean metaEnabled)
+      throws IOException {
+    FSPermissionChecker pc = getPermissionChecker();
+    if (isInSafeMode()) {
+      throw new SafeModeException("Cannot set metaEnabled for " + src,
+          safeMode);
+    }
+    if (isPermissionEnabled) {
+      checkPathAccess(pc, src, FsAction.WRITE);
+    }
+
+    INode targetNode = getINode(src);
+    if (!targetNode.isDirectory()) {
+      throw new FileNotFoundException(src + ": Is not a directory");
+    } else {
+      INodeDirectory dirNode = (INodeDirectory) targetNode;
+      dirNode.setMetaEnabled(metaEnabled);
+      EntityManager.update(dirNode);
+    }
+  }
+
+  private void logMetadataEvents(AbstractFileTree.FileTree fileTree,
+      MetadataLogEntry.Operation operation) throws TransactionContextException,
+      StorageException {
+    ProjectedINode datasetDir = fileTree.getSubtreeRoot();
+    for (ProjectedINode node : fileTree.getAllChildren()) {
+      MetadataLogEntry logEntry = new MetadataLogEntry(datasetDir.getId(),
+          node.getId(), operation);
+      EntityManager.add(logEntry);
+    }
   }
 
   long getPreferredBlockSize(final String filename) throws IOException {
@@ -3110,16 +3182,27 @@ public class FSNamesystem
       return;
     }
 
-    if (dir.isQuotaEnabled()) { //HOP
-      // Adjust disk space consumption if required
-      final long diff =
-          fileINode.getPreferredBlockSize() - commitBlock.getNumBytes();
+    if (dir.isQuotaEnabled()) {
+      final long diff = fileINode.getPreferredBlockSize()
+          - commitBlock.getNumBytes();
       if (diff > 0) {
-        String path = leaseManager.findPath(fileINode);
-        dir.updateSpaceConsumed(path, 0,
-            -diff * fileINode.getBlockReplication());
-
+      // Adjust disk space consumption if required
+      String path = leaseManager.findPath(fileINode);
+      dir.updateSpaceConsumed(path, 0,
+          -diff * fileINode.getBlockReplication());
       }
+    }
+
+    fileINode.inrementSize((int) (commitBlock.getNumBytes() / 1024));
+    try {
+      if (fileINode.isPathMetaEnabled()) {
+        SizeLogDataAccess da = (SizeLogDataAccess)
+            HdfsStorageFactory.getDataAccess(SizeLogDataAccess.class);
+        da.add(new SizeLogEntry(fileINode.getId(), fileINode.getSize()));
+      }
+    } catch (StorageCallPreventedException e) {
+      // Path is not available during block synchronization but it is OK
+      // for us if search results are off by one block
     }
   }
 
@@ -5744,7 +5827,8 @@ public class FSNamesystem
     }
 
     try {
-      INode subtreeRoot = lockSubtree(path);
+      INode[] inodes = lockSubtree(path);
+      INode subtreeRoot = inodes[inodes.length - 1];
 
       if (subtreeRoot == null) {
         throw new FileNotFoundException("Directory does not exist: " + path);
@@ -5813,7 +5897,8 @@ public class FSNamesystem
       throws AccessControlException, FileNotFoundException,
       UnresolvedLinkException, IOException {
     try {
-      final INode subtreeRoot = lockSubtree(path);
+      INode[] inodes = lockSubtree(path);
+      final INode subtreeRoot = inodes[inodes.length - 1];
       if (subtreeRoot == null) {
         throw new FileNotFoundException("File does not exist: " + path);
       }
@@ -5889,17 +5974,32 @@ public class FSNamesystem
     }
 
     try {
-      INode srcNode = lockSubtreeAndCheckPathPermission(src, false, null,
+      INode[] srcInodes = lockSubtreeAndCheckPathPermission(src, false, null,
           FsAction.WRITE, null, null);
-      INode dstNode = lockSubtreeAndCheckPathPermission(dst, false,
+      INode srcNode = srcInodes[srcInodes.length - 1];
+      INode[] dstInodes = lockSubtreeAndCheckPathPermission(dst, false,
           FsAction.WRITE, null, null, null);
+      INode dstNode = dstInodes[dstInodes.length - 1];
+
+      INode srcDataset = getMetaEnabledParent(srcInodes);
+      INode dstDataset = getMetaEnabledParent(dstInodes);
 
       long srcNsCount = 0;
       long srcDsCount = 0;
+      Collection<MetadataLogEntry> logEntries = Collections.EMPTY_LIST;
       if (srcNode != null) {
-        AbstractFileTree.QuotaCountingFileTree srcFileTree =
-            new AbstractFileTree.QuotaCountingFileTree(this, srcNode.getId());
-        srcFileTree.buildUp();
+        AbstractFileTree.QuotaCountingFileTree srcFileTree;
+        if (pathIsMetaEnabled(srcInodes) || pathIsMetaEnabled(dstInodes)) {
+          srcFileTree = new AbstractFileTree.LoggingQuotaCountingFileTree(this,
+              srcNode.getId(), srcDataset, dstDataset);
+          srcFileTree.buildUp();
+          logEntries = ((AbstractFileTree.LoggingQuotaCountingFileTree)
+              srcFileTree).getMetadataLogEntries();
+        } else {
+          srcFileTree = new AbstractFileTree.QuotaCountingFileTree(this,
+              srcNode.getId());
+          srcFileTree.buildUp();
+        }
         srcNsCount = srcFileTree.getNamespaceCount();
         srcDsCount = srcFileTree.getDiskspaceCount();
       }
@@ -5915,15 +6015,32 @@ public class FSNamesystem
       }
 
       renameTo(src, dst, srcNsCount, srcDsCount, dstNsCount, dstDsCount,
-          options);
+          logEntries, options);
     } finally {
       unlockSubtree(src);
       unlockSubtree(dst);
     }
   }
 
+  private boolean pathIsMetaEnabled(INode[] pathComponents) {
+    return getMetaEnabledParent(pathComponents) == null ? false : true;
+  }
+
+  private INode getMetaEnabledParent(INode[] pathComponents) {
+    for (INode node : pathComponents) {
+      if (node != null && node.isDirectory()) {
+        INodeDirectory dir = (INodeDirectory) node;
+        if (dir.isMetaEnabled()) {
+          return dir;
+        }
+      }
+    }
+    return null;
+  }
+
   private void renameTo(final String src, final String dst, final long srcNsCount,
       final long srcDsCount, final long dstNsCount, final long dstDsCount,
+      final Collection<MetadataLogEntry> logEntries,
       final Options.Rename... options)
       throws IOException, UnresolvedLinkException {
     new HopsTransactionalRequestHandler(HDFSOperationType.SUBTREE_RENAME, src) {
@@ -5957,6 +6074,10 @@ public class FSNamesystem
         }
         if (!DFSUtil.isValidName(dst)) {
           throw new InvalidPathException("Invalid name: " + dst);
+        }
+
+        for (MetadataLogEntry logEntry : logEntries) {
+          EntityManager.add(logEntry);
         }
 
         dir.renameTo(src, dst, srcNsCount, srcDsCount, dstNsCount, dstDsCount,
@@ -6011,17 +6132,32 @@ public class FSNamesystem
     }
 
     try {
-      INode srcNode = lockSubtreeAndCheckPathPermission(src, false, null,
+      INode[] srcNodes = lockSubtreeAndCheckPathPermission(src, false, null,
           FsAction.WRITE, null, null);
-      INode dstNode = lockSubtreeAndCheckPathPermission(actualdst, false,
+      INode srcNode = srcNodes[srcNodes.length - 1];
+      INode[] dstNodes = lockSubtreeAndCheckPathPermission(actualdst, false,
           FsAction.WRITE, null, null, null);
+      INode dstNode = dstNodes[dstNodes.length - 1];
+
+      INode srcDataset = getMetaEnabledParent(srcNodes);
+      INode dstDataset = getMetaEnabledParent(dstNodes);
 
       long srcNsCount = 0;
       long srcDsCount = 0;
+      Collection<MetadataLogEntry> logEntries = Collections.EMPTY_LIST;
       if (srcNode != null) {
-        AbstractFileTree.QuotaCountingFileTree srcFileTree =
-            new AbstractFileTree.QuotaCountingFileTree(this, srcNode.getId());
-        srcFileTree.buildUp();
+        AbstractFileTree.QuotaCountingFileTree srcFileTree;
+        if (pathIsMetaEnabled(srcNodes) || pathIsMetaEnabled(dstNodes)) {
+          srcFileTree = new AbstractFileTree.LoggingQuotaCountingFileTree(this,
+              srcNode.getId(), srcDataset, dstDataset);
+          srcFileTree.buildUp();
+          logEntries = ((AbstractFileTree.LoggingQuotaCountingFileTree)
+              srcFileTree).getMetadataLogEntries();
+        } else {
+          srcFileTree = new AbstractFileTree.QuotaCountingFileTree(this,
+              srcNode.getId());
+          srcFileTree.buildUp();
+        }
         srcNsCount = srcFileTree.getNamespaceCount();
         srcDsCount = srcFileTree.getDiskspaceCount();
       }
@@ -6036,7 +6172,8 @@ public class FSNamesystem
         dstDsCount = dstFileTree.getDiskspaceCount();
       }
 
-      return renameTo(src, dst, srcNsCount, srcDsCount, dstNsCount, dstDsCount);
+      return renameTo(src, dst, srcNsCount, srcDsCount, dstNsCount, dstDsCount,
+          logEntries);
     } finally {
       unlockSubtree(src);
       unlockSubtree(actualdst);
@@ -6051,7 +6188,8 @@ public class FSNamesystem
    */
   @Deprecated
   boolean renameTo(final String src, final String dst, final long srcNsCount,
-      final long srcDsCount, final long dstNsCount, final long dstDsCount)
+      final long srcDsCount, final long dstNsCount, final long dstDsCount,
+      final Collection<MetadataLogEntry> logEntries)
       throws IOException, UnresolvedLinkException {
     HopsTransactionalRequestHandler renameToHandler =
         new HopsTransactionalRequestHandler(HDFSOperationType.RENAME_TO, src) {
@@ -6082,6 +6220,10 @@ public class FSNamesystem
             }
             if (!DFSUtil.isValidName(dst)) {
               throw new IOException("Invalid name: " + dst);
+            }
+
+            for (MetadataLogEntry logEntry : logEntries) {
+              EntityManager.add(logEntry);
             }
 
             return dir.renameTo(src, dst, srcNsCount, srcDsCount, dstNsCount,
@@ -6136,9 +6278,10 @@ public class FSNamesystem
     }
 
     try {
-      INode subtreeRoot =
-          lockSubtreeAndCheckPathPermission(path, false, null, FsAction.WRITE,
-              null, null);
+      INode[] inodes = lockSubtreeAndCheckPathPermission(path, false, null,
+          FsAction.WRITE, null, null);
+      INode subtreeRoot = inodes[inodes.length - 1];
+
       if (subtreeRoot == null) {
         NameNode.stateChangeLog
             .debug("Failed to remove " + path + " because it does not exist");
@@ -6264,7 +6407,7 @@ public class FSNamesystem
    * @throws IOException
    */
   @VisibleForTesting
-  INode lockSubtree(final String path) throws IOException {
+  INode[] lockSubtree(final String path) throws IOException {
     return lockSubtreeAndCheckPathPermission(path, false, null, null, null,
         null);
   }
@@ -6291,11 +6434,11 @@ public class FSNamesystem
    * @throws IOException
    */
   @VisibleForTesting
-  INode lockSubtreeAndCheckPathPermission(final String path,
+  INode[] lockSubtreeAndCheckPathPermission(final String path,
       final boolean doCheckOwner, final FsAction ancestorAccess,
       final FsAction parentAccess, final FsAction access,
       final FsAction subAccess) throws IOException {
-    return (INode) new HopsTransactionalRequestHandler(
+    return (INode[]) new HopsTransactionalRequestHandler(
         HDFSOperationType.SET_SUBTREE_LOCK) {
       @Override
       public void acquireLock(TransactionLocks locks) throws IOException {
@@ -6319,7 +6462,7 @@ public class FSNamesystem
           inode.setSubtreeLockOwner(getNamenodeId());
           EntityManager.update(inode);
         }
-        return inode;
+        return nodes;
       }
     }.handle(this);
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
@@ -22,8 +22,12 @@ import io.hops.erasure_coding.ErasureCodingManager;
 import io.hops.exception.HopsException;
 import io.hops.exception.StorageException;
 import io.hops.exception.TransactionContextException;
+import io.hops.metadata.HdfsStorageFactory;
 import io.hops.metadata.common.FinderType;
+import io.hops.metadata.hdfs.dal.AccessTimeLogDataAccess;
+import io.hops.metadata.hdfs.entity.AccessTimeLogEntry;
 import io.hops.metadata.hdfs.entity.EncodingStatus;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.transaction.EntityManager;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.ContentSummary;
@@ -32,8 +36,10 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.permission.PermissionStatus;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -668,8 +674,14 @@ public abstract class INode implements Comparable<byte[]> {
   }
 
   public void setAccessTime(long atime)
-      throws StorageException, TransactionContextException {
+      throws TransactionContextException, StorageException {
     setAccessTimeNoPersistance(atime);
+    if (isPathMetaEnabled()) {
+      AccessTimeLogDataAccess da = (AccessTimeLogDataAccess)
+          HdfsStorageFactory.getDataAccess(AccessTimeLogDataAccess.class);
+      int userId = -1; // TODO get userId
+      da.add(new AccessTimeLogEntry(getId(), userId, atime));
+    }
     save();
   }
 
@@ -754,5 +766,29 @@ public abstract class INode implements Comparable<byte[]> {
 
   long getPermission() {
     return permission;
+  }
+
+  void logMetadataEvent(MetadataLogEntry.Operation operation)
+      throws StorageException, TransactionContextException {
+    if (isPathMetaEnabled()) {
+      INodeDirectory datasetDir = getMetaEnabledParent();
+      EntityManager.add(new MetadataLogEntry(datasetDir.getId(), getId(), operation));
+    }
+  }
+
+  boolean isPathMetaEnabled() throws TransactionContextException, StorageException {
+    return getMetaEnabledParent() != null ? true : false;
+  }
+
+  INodeDirectory getMetaEnabledParent()
+      throws TransactionContextException, StorageException {
+    INodeDirectory dir = getParent();
+    while (!isRoot() && !dir.isRoot()) {
+      if (dir.isMetaEnabled()) {
+        return dir;
+      }
+      dir = dir.getParent();
+    }
+    return null;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INodeFile.java
@@ -19,8 +19,12 @@ package org.apache.hadoop.hdfs.server.namenode;
 
 import io.hops.exception.StorageException;
 import io.hops.exception.TransactionContextException;
+import io.hops.metadata.HdfsStorageFactory;
+import io.hops.metadata.hdfs.dal.MetadataLogDataAccess;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.transaction.EntityManager;
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.fs.UnresolvedLinkException;
 import org.apache.hadoop.fs.permission.PermissionStatus;
 import org.apache.hadoop.hdfs.protocol.Block;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
@@ -62,6 +66,7 @@ public class INodeFile extends INode implements BlockCollection {
 
   private long header;
   private int generationStamp = (int) GenerationStamp.FIRST_VALID_STAMP;
+  private int size;
   
 
   public INodeFile(PermissionStatus permissions, BlockInfo[] blklist,
@@ -85,6 +90,7 @@ public class INodeFile extends INode implements BlockCollection {
     setReplicationNoPersistance(other.getBlockReplication());
     setPreferredBlockSizeNoPersistance(other.getPreferredBlockSize());
     setGenerationStampNoPersistence(other.getGenerationStamp());
+    setSize(other.getSize());
   }
 
   /**
@@ -372,4 +378,17 @@ public class INodeFile extends INode implements BlockCollection {
     return generationStamp;
   }
 
+  public int getSize() {
+    return size;
+  }
+
+  public void setSize(int size) {
+    this.size = size;
+  }
+
+  public void inrementSize(int increment)
+      throws TransactionContextException, StorageException {
+    this.size += increment;
+    save();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -88,6 +88,7 @@ import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ipc.WritableRpcEngine;
 import org.apache.hadoop.net.Node;
+import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.Groups;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
@@ -106,6 +107,7 @@ import org.apache.hadoop.tools.protocolPB.GetUserMappingsProtocolServerSideTrans
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.hadoop.util.VersionUtil;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -411,6 +413,13 @@ class NameNodeRpcServer implements NamenodeProtocols {
   public boolean setReplication(String src, short replication)
       throws IOException {
     return namesystem.setReplication(src, replication);
+  }
+
+  @Override // ClientProtocol
+  public void setMetaEnabled(String src, boolean metaEnabled)
+      throws AccessControlException, FileNotFoundException, SafeModeException,
+      UnresolvedLinkException, IOException {
+    namesystem.setMetaEnabled(src, metaEnabled);
   }
 
   @Override // ClientProtocol

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/ClientNamenodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/ClientNamenodeProtocol.proto
@@ -127,6 +127,14 @@ message SetReplicationResponseProto {
   required bool result = 1;
 }
 
+message SetMetaEnabledRequestProto {
+  required string src = 1;
+  required bool metaEnabled = 2;
+}
+
+message SetMetaEnabledResponseProto {// void response
+}
+
 message SetPermissionRequestProto {
   required string src = 1;
   required FsPermissionProto permission = 2;
@@ -521,6 +529,7 @@ service ClientNamenodeProtocol {
   rpc create (CreateRequestProto) returns (CreateResponseProto);
   rpc append (AppendRequestProto) returns (AppendResponseProto);
   rpc setReplication (SetReplicationRequestProto) returns (SetReplicationResponseProto);
+  rpc setMetaEnabled (SetMetaEnabledRequestProto) returns (SetMetaEnabledResponseProto);
   rpc setPermission (SetPermissionRequestProto) returns (SetPermissionResponseProto);
   rpc setOwner (SetOwnerRequestProto) returns (SetOwnerResponseProto);
   rpc abandonBlock (AbandonBlockRequestProto) returns (AbandonBlockResponseProto);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/TestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/TestUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops;
+
+import io.hops.transaction.handler.HDFSOperationType;
+import io.hops.transaction.handler.HopsTransactionalRequestHandler;
+import io.hops.transaction.lock.LockFactory;
+import io.hops.transaction.lock.TransactionLockTypes;
+import io.hops.transaction.lock.TransactionLocks;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.server.namenode.INode;
+import org.apache.hadoop.hdfs.server.namenode.NameNode;
+
+import java.io.IOException;
+
+public class TestUtil {
+
+  /**
+   * Get the inodeId for a file.
+   *
+   * @param nameNode the NameNode
+   * @param path the path to the file
+   * @return the inodeId
+   * @throws IOException
+   */
+  public static int getINodeId(final NameNode nameNode, final Path path)
+      throws IOException {
+    final String filePath = path.toUri().getPath();
+    return (Integer) new HopsTransactionalRequestHandler(
+        HDFSOperationType.TEST) {
+      @Override
+      public void acquireLock(TransactionLocks locks) throws IOException {
+        LockFactory lf = LockFactory.getInstance();
+        locks.add(lf.getINodeLock(nameNode,
+            TransactionLockTypes.INodeLockType.READ_COMMITTED,
+            TransactionLockTypes.INodeResolveType.PATH, filePath));
+      }
+
+      @Override
+      public Object performTask() throws IOException {
+        INode targetNode = nameNode.getNamesystem().getINode(filePath);
+        return targetNode.getId();
+      }
+    }.handle();
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestAccessTimeLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestAccessTimeLog.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import io.hops.TestUtil;
+import io.hops.metadata.HdfsStorageFactory;
+import io.hops.metadata.hdfs.dal.AccessTimeLogDataAccess;
+import io.hops.metadata.hdfs.entity.AccessTimeLogEntry;
+import io.hops.transaction.handler.HDFSOperationType;
+import io.hops.transaction.handler.LightWeightRequestHandler;
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class TestAccessTimeLog extends TestCase {
+
+  private int getLogEntryCount(final int inodeId) throws IOException {
+    return (Integer) new LightWeightRequestHandler(HDFSOperationType.TEST) {
+      @Override
+      public Object performTask() throws IOException {
+        AccessTimeLogDataAccess<AccessTimeLogEntry> da =
+            (AccessTimeLogDataAccess) HdfsStorageFactory.getDataAccess(
+                AccessTimeLogDataAccess.class);
+        Collection<AccessTimeLogEntry> logEntries = da.find(inodeId);
+        return logEntries.size();
+      }
+    }.handle();
+  }
+
+  @Test
+  public void testAccessTime() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_ACCESSTIME_PRECISION_KEY, 1);
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      final Path subdir = new Path(dataset, "subdir");
+      Path file = new Path(subdir, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset, true);
+      dfs.mkdirs(subdir);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      out.close();
+      FSDataInputStream in = dfs.open(file);
+      in.close();
+      int fileId = TestUtil.getINodeId(cluster.getNameNode(), file);
+      assertEquals(2, getLogEntryCount(fileId));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testNonLoggingDir() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_ACCESSTIME_PRECISION_KEY, 1);
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      final Path subdir = new Path(dataset, "subdir");
+      Path file = new Path(subdir, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.mkdirs(subdir);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      out.close();
+      FSDataInputStream in = dfs.open(file);
+      in.close();
+      int fileId = TestUtil.getINodeId(cluster.getNameNode(), file);
+      assertEquals(0, getLogEntryCount(fileId));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMetadataLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestMetadataLog.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import io.hops.TestUtil;
+import io.hops.metadata.HdfsStorageFactory;
+import io.hops.metadata.hdfs.dal.MetadataLogDataAccess;
+import io.hops.metadata.hdfs.entity.MetadataLogEntry;
+import io.hops.transaction.handler.HDFSOperationType;
+import io.hops.transaction.handler.LightWeightRequestHandler;
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class TestMetadataLog extends TestCase {
+  private static final int ANY_DATASET = -1;
+
+  private boolean checkLog(int inodeId, MetadataLogEntry.Operation operation)
+      throws IOException {
+    return checkLog(ANY_DATASET, inodeId, operation);
+  }
+
+  private boolean checkLog(int datasetId, int inodeId,
+      MetadataLogEntry.Operation operation) throws IOException {
+    Collection<MetadataLogEntry> logEntries = getMetadataLogEntries(inodeId);
+    for (MetadataLogEntry logEntry : logEntries) {
+      if (logEntry.getOperation().equals(operation)) {
+        if (datasetId == ANY_DATASET || datasetId == logEntry.getDatasetId()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private Collection<MetadataLogEntry> getMetadataLogEntries(final int inodeId)
+      throws IOException {
+    return (Collection<MetadataLogEntry>) new LightWeightRequestHandler(
+        HDFSOperationType.GET_METADATA_LOG_ENTRIES) {
+      @Override
+      public Object performTask() throws IOException {
+        MetadataLogDataAccess da = (MetadataLogDataAccess)
+            HdfsStorageFactory.getDataAccess(MetadataLogDataAccess.class);
+        return da.find(inodeId);
+      }
+    }.handle();
+  }
+
+  @Test
+  public void testNonLoggingFolder() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      final Path subdir = new Path(dataset, "subdir");
+      Path file = new Path(dataset, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.mkdirs(subdir);
+      assertFalse(checkLog(TestUtil.getINodeId(cluster.getNameNode(), subdir),
+          MetadataLogEntry.Operation.ADD));
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      out.close();
+      assertFalse(checkLog(TestUtil.getINodeId(cluster.getNameNode(), file),
+          MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      final Path subdir = new Path(dataset, "subdir");
+      Path file = new Path(subdir, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset, true);
+      dfs.mkdirs(subdir);
+      assertTrue(checkLog(TestUtil.getINodeId(cluster.getNameNode(), subdir),
+          MetadataLogEntry.Operation.ADD));
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      out.close();
+      assertTrue(checkLog(TestUtil.getINodeId(cluster.getNameNode(), file),
+          MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testNoLogEntryBeforeClosing() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      Path file = new Path(dataset, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset, true);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      assertFalse(checkLog(TestUtil.getINodeId(cluster.getNameNode(), file),
+          MetadataLogEntry.Operation.ADD));
+      out.close();
+      assertTrue(checkLog(TestUtil.getINodeId(cluster.getNameNode(), file),
+          MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      Path dataset = new Path(project, "dataset");
+      Path folder = new Path(dataset, "folder");
+      Path file = new Path(folder, "file");
+      dfs.mkdirs(folder, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset, true);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      out.close();
+      int inodeId = TestUtil.getINodeId(cluster.getNameNode(), file);
+      int folderId = TestUtil.getINodeId(cluster.getNameNode(), folder);
+      assertTrue(checkLog(folderId, MetadataLogEntry.Operation.ADD));
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.ADD));
+      dfs.delete(folder, true);
+      assertTrue(checkLog(folderId, MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.DELETE));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testOldRename() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      Path dataset0 = new Path(project, "dataset0");
+      Path dataset1 = new Path(project, "dataset1");
+      Path file0 = new Path(dataset0, "file");
+      Path file1 = new Path(dataset1, "file");
+      dfs.mkdirs(dataset0, FsPermission.getDefault());
+      dfs.mkdirs(dataset1, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset0, true);
+      dfs.setMetaEnabled(dataset1, true);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file0, 1);
+      out.close();
+      int inodeId = TestUtil.getINodeId(cluster.getNameNode(), file0);
+      int dataset0Id = TestUtil.getINodeId(cluster.getNameNode(), dataset0);
+      int dataset1Id = TestUtil.getINodeId(cluster.getNameNode(), dataset1);
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.ADD));
+      assertTrue(dfs.rename(file0, file1));
+      assertTrue(checkLog(dataset0Id, inodeId,
+          MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(dataset1Id, inodeId, MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  public void testRename() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      Path dataset0 = new Path(project, "dataset0");
+      Path dataset1 = new Path(project, "dataset1");
+      Path file0 = new Path(dataset0, "file");
+      Path file1 = new Path(dataset1, "file");
+      dfs.mkdirs(dataset0, FsPermission.getDefault());
+      dfs.mkdirs(dataset1, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset0, true);
+      dfs.setMetaEnabled(dataset1, true);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file0, 1);
+      out.close();
+      int inodeId = TestUtil.getINodeId(cluster.getNameNode(), file0);
+      int dataset0Id = TestUtil.getINodeId(cluster.getNameNode(), dataset0);
+      int dataset1Id = TestUtil.getINodeId(cluster.getNameNode(), dataset1);
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.ADD));
+      dfs.rename(file0, file1, Options.Rename.NONE);
+      assertTrue(checkLog(dataset0Id, inodeId,
+          MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(dataset1Id, inodeId, MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testDeepOldRename() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      Path dataset0 = new Path(project, "dataset0");
+      Path folder0 = new Path(dataset0, "folder0");
+      Path dataset1 = new Path(project, "dataset1");
+      Path folder1 = new Path(dataset1, "folder1");
+      Path file0 = new Path(folder0, "file");
+
+      dfs.mkdirs(folder0, FsPermission.getDefault());
+      dfs.mkdirs(dataset1, FsPermission.getDefault());
+
+      dfs.setMetaEnabled(dataset0, true);
+      dfs.setMetaEnabled(dataset1, true);
+
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file0, 1);
+      out.close();
+
+      int inodeId = TestUtil.getINodeId(cluster.getNameNode(), file0);
+      int folder0Id = TestUtil.getINodeId(cluster.getNameNode(), folder0);
+      int dataset0Id = TestUtil.getINodeId(cluster.getNameNode(), dataset0);
+      int dataset1Id = TestUtil.getINodeId(cluster.getNameNode(), dataset1);
+
+      assertTrue(checkLog(dataset0Id, folder0Id, MetadataLogEntry.Operation.ADD));
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.ADD));
+
+      dfs.rename(folder0, folder1);
+
+      int folder1Id = TestUtil.getINodeId(cluster.getNameNode(), folder1);
+      assertTrue(checkLog(dataset0Id, folder0Id,
+          MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(dataset0Id, inodeId,
+          MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(dataset1Id, folder1Id, MetadataLogEntry.Operation.ADD));
+      assertTrue(checkLog(dataset1Id, inodeId, MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testDeepRename() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      Path dataset0 = new Path(project, "dataset0");
+      Path folder0 = new Path(dataset0, "folder0");
+      Path dataset1 = new Path(project, "dataset1");
+      Path folder1 = new Path(dataset1, "folder1");
+      Path file0 = new Path(folder0, "file");
+
+      dfs.mkdirs(folder0, FsPermission.getDefault());
+      dfs.mkdirs(dataset1, FsPermission.getDefault());
+
+      dfs.setMetaEnabled(dataset0, true);
+      dfs.setMetaEnabled(dataset1, true);
+
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file0, 1);
+      out.close();
+
+      int inodeId = TestUtil.getINodeId(cluster.getNameNode(), file0);
+      int folder0Id = TestUtil.getINodeId(cluster.getNameNode(), folder0);
+      int dataset0Id = TestUtil.getINodeId(cluster.getNameNode(), dataset0);
+      int dataset1Id = TestUtil.getINodeId(cluster.getNameNode(), dataset1);
+
+      assertTrue(checkLog(dataset0Id, folder0Id, MetadataLogEntry.Operation.ADD));
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.ADD));
+
+      dfs.rename(folder0, folder1, Options.Rename.NONE);
+
+      int folder1Id = TestUtil.getINodeId(cluster.getNameNode(), folder1);
+      assertTrue(checkLog(dataset0Id, folder0Id,
+          MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(dataset0Id, inodeId,
+          MetadataLogEntry.Operation.DELETE));
+      assertTrue(checkLog(dataset1Id, folder1Id, MetadataLogEntry.Operation.ADD));
+      assertTrue(checkLog(dataset1Id, inodeId, MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testEnableLogForExistingDirectory() throws Exception {
+    Configuration conf = new HdfsConfiguration();
+    conf.setBoolean(DFSConfigKeys.DFS_LEGACY_DELETE_ENABLE_KEY, true);
+    MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(2)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      Path dataset = new Path(project, "dataset");
+      Path folder = new Path(dataset, "dataset");
+      Path file = new Path(folder, "file");
+      dfs.mkdirs(folder, FsPermission.getDefault());
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      out.close();
+      dfs.setMetaEnabled(dataset, true);
+      int inodeId = TestUtil.getINodeId(cluster.getNameNode(), file);
+      int folderId = TestUtil.getINodeId(cluster.getNameNode(), folder);
+      assertTrue(checkLog(folderId, MetadataLogEntry.Operation.ADD));
+      assertTrue(checkLog(inodeId, MetadataLogEntry.Operation.ADD));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+}

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestSizeLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestSizeLog.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import io.hops.TestUtil;
+import io.hops.metadata.HdfsStorageFactory;
+import io.hops.metadata.hdfs.dal.SizeLogDataAccess;
+import io.hops.metadata.hdfs.entity.SizeLogEntry;
+import io.hops.transaction.handler.HDFSOperationType;
+import io.hops.transaction.handler.LightWeightRequestHandler;
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class TestSizeLog extends TestCase {
+
+  private int getLogEntryCount(final int inodeId) throws IOException {
+    return (Integer) new LightWeightRequestHandler(HDFSOperationType.TEST) {
+      @Override
+      public Object performTask() throws IOException {
+        SizeLogDataAccess<SizeLogEntry> da = (SizeLogDataAccess)
+            HdfsStorageFactory.getDataAccess(SizeLogDataAccess.class);
+        Collection<SizeLogEntry> logEntries = da.find(inodeId);
+        return logEntries.size();
+      }
+    }.handle();
+  }
+
+  @Test
+  public void testSize() throws Exception {
+    int blockSize = 8192;
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      final Path subdir = new Path(dataset, "subdir");
+      Path file = new Path(subdir, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.setMetaEnabled(dataset, true);
+      dfs.mkdirs(subdir);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      int addSize = 1024;
+      int size = 3 * blockSize + addSize;
+      TestFileCreation.writeFile(out, size);
+      out.close();
+      int fileId = TestUtil.getINodeId(cluster.getNameNode(), file);
+      assertEquals(4, getLogEntryCount(fileId));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+
+  @Test
+  public void testNonLoggingDir() throws Exception {
+    int blockSize = 8192;
+    Configuration conf = new HdfsConfiguration();
+    conf.setInt(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, blockSize);
+    final MiniDFSCluster cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(1)
+        .build();
+    try {
+      DistributedFileSystem dfs = cluster.getFileSystem();
+      Path projects = new Path("/projects");
+      Path project = new Path(projects, "project");
+      final Path dataset = new Path(project, "dataset");
+      final Path subdir = new Path(dataset, "subdir");
+      Path file = new Path(subdir, "file");
+      dfs.mkdirs(dataset, FsPermission.getDefault());
+      dfs.mkdirs(subdir);
+      HdfsDataOutputStream out = TestFileCreation.create(dfs, file, 1);
+      int addSize = 1024;
+      int size = 3 * blockSize + addSize;
+      TestFileCreation.writeFile(out, size);
+      out.close();
+      int fileId = TestUtil.getINodeId(cluster.getNameNode(), file);
+      assertEquals(0, getLogEntryCount(fileId));
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added, deleted and renamed files as well as per user access times and file sizes are written to speciel log tables and available for a consumer.
Directories do now have a metadata enabled flag. All operations in the filetree under an enabled directory will be logged.
It can be enabled per directory using DistributedFileSystem.setMetaEnabled(Path src, boolean metaEnabled).