### PR TITLE
Erasure Coding: Copy files in the mapper instead of the client

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
@@ -204,7 +204,8 @@ public final class Options {
    */
   public static enum Rename {
     NONE((byte) 0), // No options
-    OVERWRITE((byte) 1); // Overwrite the rename destination
+    OVERWRITE((byte) 1),
+    KEEP_ENCODING_STATUS((byte)2 ); // Overwrite the rename destination
 
     private final byte code;
     

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/erasure_coding/EncodingManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/erasure_coding/EncodingManager.java
@@ -30,7 +30,7 @@ public abstract class EncodingManager extends Configured
   }
 
   public abstract void encodeFile(EncodingPolicy policy, Path sourceFile,
-      Path parityFile);
+      Path parityFile, boolean copy);
 
   public abstract List<Report> computeReports();
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/erasure_coding/ErasureCodingManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/erasure_coding/ErasureCodingManager.java
@@ -360,12 +360,14 @@ public class ErasureCodingManager extends Configured {
 
         LOG.info("Schedule encoding for " + path);
         UUID parityFileName = UUID.randomUUID();
-        encodingManager
-            .encodeFile(encodingStatus.getEncodingPolicy(), new Path(path),
-                new Path(parityFolder + "/" + parityFileName.toString()));
-        namesystem
-            .updateEncodingStatus(path, EncodingStatus.Status.ENCODING_ACTIVE,
-                parityFileName.toString());
+        encodingManager.encodeFile(
+            encodingStatus.getEncodingPolicy(),
+            new Path(path),
+            new Path(parityFolder + "/" + parityFileName.toString()),
+            encodingStatus.getStatus() ==
+                EncodingStatus.Status.COPY_ENCODING_REQUESTED ? true : false);
+        namesystem.updateEncodingStatus(path,
+            EncodingStatus.Status.ENCODING_ACTIVE, parityFileName.toString());
         activeEncodings++;
       } catch (IOException e) {
         LOG.error(StringUtils.stringifyException(e));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -3027,7 +3027,6 @@ public class DFSClient implements java.io.Closeable {
    */
   public void encodeFile(final String filePath, final EncodingPolicy policy)
       throws IOException {
-    // TODO STEFFEN - Not used for now because of placement enforcement hack
     ClientActionHandler handler = new ClientActionHandler() {
       @Override
       public Object doAction(ClientProtocol namenode) throws IOException {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -132,7 +132,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_NAMENODE_SELECTOR_POLICY_KEY =
       "dfs.namenode.selector-policy";
   public static final String DFS_NAMENODE_SELECTOR_POLICY_DEFAULT =
-      "ROUND_ROBIN";     //RANDOM
+      "RANDOM_STICKY";     //RANDOM ROUND_ROBIN RANDOM_STICKY
   
   public static final String DFS_BLOCK_POOL_ID_KEY = "dfs.block.pool.id";
   public static final String DFS_BLOCK_POOL_ID_DEFAULT = "HOP_BLOCK_POOL_123";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -80,6 +80,7 @@ import java.nio.BufferOverflowException;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -157,9 +158,10 @@ public class DFSOutputStream extends FSOutputSummer implements Syncable {
   private int currentBlockIndex = 0;
   private int stripeLength;
   private int parityLength;
-  private ArrayList<LocatedBlock> sourceBlocks;
+  private List<LocatedBlock> sourceBlocks = Collections.emptyList();
   private List<DatanodeInfo> stripeNodes = new LinkedList<DatanodeInfo>();
-  
+  private List<DatanodeInfo> parityStripeNodes = new LinkedList<DatanodeInfo>();
+
   private class Packet {
     long seqno;               // sequencenumber of buffer in block
     long offsetInBlock;       // offset in block
@@ -1136,7 +1138,7 @@ public class DFSOutputStream extends FSOutputSummer implements Syncable {
 
         if (erasureCodingSourceStream || erasureCodingParityStream) {
           excluded = new DatanodeInfo[excludedNodes.size() + usedNodes.size() +
-              stripeNodes.size()];
+              stripeNodes.size() + parityStripeNodes.size()];
           int i = 0;
           for (DatanodeInfo node : excludedNodes) {
             excluded[i] = node;
@@ -1148,6 +1150,11 @@ public class DFSOutputStream extends FSOutputSummer implements Syncable {
             i++;
           }
           for (DatanodeInfo node : stripeNodes) {
+            excluded[i] = node;
+            LOG.info("Block " + currentBlockIndex + " excluding " + node);
+            i++;
+          }
+          for (DatanodeInfo node : parityStripeNodes) {
             excluded[i] = node;
             LOG.info("Block " + currentBlockIndex + " excluding " + node);
             i++;
@@ -2083,10 +2090,11 @@ public class DFSOutputStream extends FSOutputSummer implements Syncable {
     this.erasureCodingParityStream = true;
     this.stripeLength = stripeLength;
     this.parityLength = parityLength;
-    this.sourceBlocks = new ArrayList(
-        dfsClient.getLocatedBlocks(sourceFile, 0, Long.MAX_VALUE)
-            .getLocatedBlocks());
-    Collections.sort(sourceBlocks, LocatedBlock.blockIdComparator);
+    if (sourceFile != null) {
+      this.sourceBlocks = new ArrayList(dfsClient.getLocatedBlocks(
+          sourceFile, 0, Long.MAX_VALUE).getLocatedBlocks());
+      Collections.sort(sourceBlocks, LocatedBlock.blockIdComparator);
+    }
   }
 
   @Override
@@ -2095,5 +2103,15 @@ public class DFSOutputStream extends FSOutputSummer implements Syncable {
       IOException e = lastException;
       throw e != null ? e : new ClosedChannelException();
     }
+  }
+
+  public Collection<DatanodeInfo> getUsedNodes() {
+    return usedNodes;
+  }
+
+  public void setParityStripeNodesForNextStripe(
+      Collection<DatanodeInfo> locations) {
+    parityStripeNodes.clear();
+    parityStripeNodes.addAll(locations);
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -1114,10 +1114,9 @@ public class DistributedFileSystem extends FileSystem {
   /**
    * Request the encoding for the given file according to the given policy.
    * The encoding is executed asynchronously depending on the current utilization
-   * of the cluster.
-   *
-   * NOTE: The current implementation will require the client to read and
-   * rewrite the entire file.
+   * of the cluster. NOTE: This requires the whole file to be rewritten in order
+   * to ensure durability constraints for the encoded file. Clients reading the
+   * file might fail while it is rewritten.
    *
    * @param filePath
    *    the path of the file
@@ -1127,40 +1126,7 @@ public class DistributedFileSystem extends FileSystem {
    */
   public void encodeFile(final String filePath, final EncodingPolicy policy)
       throws IOException {
-    // TODO STEFFEN - This is a quick and dirty solution to enforce block placement but it is really slow and expensive.
-    // Instead we should ensure the block placement by namenode mechanisums and only
-    // decrease the replication factor after successfully encoding
-    //dfs.encodeFile(filePath, policy);
-    Path path = new Path(filePath);
-    FileStatus status = getFileStatus(path);
-    FSDataOutputStream out = null;
-    try {
-      Path tmpFile = new Path("/tmp" + filePath);
-      out = create(tmpFile, status.getReplication(), policy);
-      FSDataInputStream in = open(path);
-      byte[] b = new byte[getConf().getInt("io.file.buffer.size", 4096)];
-      while (in.read(b) > 0) {
-        out.write(b);
-      }
-      try {
-        in.close();
-      } catch (IOException e) {
-      }
-      try {
-        out.close();
-      } catch (IOException e) {
-      }
-
-      delete(path);
-      rename(tmpFile, path);
-    } finally {
-      if (out != null) {
-        try {
-          out.close();
-        } catch (IOException e) {
-        }
-      }
-    }
+    dfs.encodeFile(filePath, policy);
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FsServerDefaults;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.hdfs.protocol.ClientProtocol;
 import org.apache.hadoop.hdfs.protocol.CorruptFileBlocks;
@@ -493,8 +494,15 @@ public class ClientNamenodeProtocolServerSideTranslatorPB
       Rename2RequestProto req) throws ServiceException {
 
     try {
-      server.rename2(req.getSrc(), req.getDst(),
-          req.getOverwriteDest() ? Rename.OVERWRITE : Rename.NONE);
+      Options.Rename[] options;
+      if (req.hasKeepEncodingStatus() && req.getKeepEncodingStatus()) {
+        options = new Rename[2];
+        options[1] = Rename.KEEP_ENCODING_STATUS;
+      } else {
+        options = new Rename[1];
+      }
+      options[0] = req.getOverwriteDest() ? Rename.OVERWRITE : Rename.NONE;
+      server.rename2(req.getSrc(), req.getDst(), options);
     } catch (IOException e) {
       throw new ServiceException(e);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -436,16 +436,21 @@ public class ClientNamenodeProtocolTranslatorPB
       NSQuotaExceededException, ParentNotDirectoryException, SafeModeException,
       UnresolvedLinkException, IOException {
     boolean overwrite = false;
+    boolean keepEncodingStatus = false;
     if (options != null) {
       for (Rename option : options) {
         if (option == Rename.OVERWRITE) {
           overwrite = true;
+        }
+        if (option == Rename.KEEP_ENCODING_STATUS) {
+          keepEncodingStatus = true;
         }
       }
     }
     Rename2RequestProto req = Rename2RequestProto.newBuilder().
         setSrc(src).
         setDst(dst).setOverwriteDest(overwrite).
+        setKeepEncodingStatus(keepEncodingStatus).
         build();
     try {
       rpcProxy.rename2(null, req);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FileDataServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FileDataServlet.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.common.JspHelper;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ServletUtil;
 
@@ -39,7 +40,7 @@ import java.security.PrivilegedExceptionAction;
 /**
  * Redirect queries about the hosted filesystem to an appropriate datanode.
  *
- * @see org.apache.hadoop.hdfs.HftpFileSystem
+ * @see HftpFileSystem
  */
 @InterfaceAudience.Private
 public class FileDataServlet extends DfsServlet {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ListPathsServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ListPathsServlet.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hdfs.server.namenode;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.HftpFileSystem;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.hdfs.protocol.ClientProtocol;
 import org.apache.hadoop.hdfs.protocol.DirectoryListing;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
@@ -45,7 +45,7 @@ import java.util.regex.Pattern;
 /**
  * Obtain meta-information about a filesystem.
  *
- * @see org.apache.hadoop.hdfs.HftpFileSystem
+ * @see HftpFileSystem
  */
 @InterfaceAudience.Private
 public class ListPathsServlet extends DfsServlet {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1008,7 +1008,8 @@ class NameNodeRpcServer implements NamenodeProtocols {
             blockSize);
     if (policy != null && namesystem.isErasureCodingEnabled()) {
       LOG.info("Create file " + src + " with policy " + policy.toString());
-      namesystem.addEncodingStatus(src, policy);
+      namesystem.addEncodingStatus(src, policy,
+          EncodingStatus.Status.ENCODING_REQUESTED);
     }
     return stat;
   }
@@ -1030,7 +1031,8 @@ class NameNodeRpcServer implements NamenodeProtocols {
       throws IOException {
     // TODO Check file access rights?
     // TODO STEFFEN - Throw error if already encoded
-    namesystem.addEncodingStatus(filePath, policy);
+    namesystem.addEncodingStatus(filePath, policy,
+        EncodingStatus.Status.COPY_ENCODING_REQUESTED);
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DelegationTokenFetcher.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DelegationTokenFetcher.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.hdfs.HftpFileSystem;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenSecretManager;
 import org.apache.hadoop.hdfs.server.namenode.CancelDelegationTokenServlet;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/ByteRangeInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/ByteRangeInputStream.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HttpHeaders;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/HftpFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/HftpFileSystem.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -31,11 +31,12 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.MD5MD5CRC32FileChecksum;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenSelector;
 import org.apache.hadoop.hdfs.server.common.JspHelper;
 import org.apache.hadoop.hdfs.tools.DelegationTokenFetcher;
-import org.apache.hadoop.hdfs.web.URLUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.net.NetUtils;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/HsftpFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/HsftpFileSystem.java
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.hdfs.web.URLUtils;
 import org.apache.hadoop.util.Time;
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/WebHdfsFileSystem.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.ParentNotDirectoryException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdfs.ByteRangeInputStream;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.protocol.DSQuotaExceededException;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/ClientNamenodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/ClientNamenodeProtocol.proto
@@ -216,6 +216,7 @@ message Rename2RequestProto {
   required string src = 1;
   required string dst = 2;
   required bool overwriteDest = 3;
+  optional bool keepEncodingStatus = 4;
 }
 
 message Rename2ResponseProto { // void response

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 org.apache.hadoop.hdfs.DistributedFileSystem
-org.apache.hadoop.hdfs.HftpFileSystem
-org.apache.hadoop.hdfs.HsftpFileSystem
+org.apache.hadoop.hdfs.web.HftpFileSystem
+org.apache.hadoop.hdfs.web.HsftpFileSystem
 org.apache.hadoop.hdfs.web.WebHdfsFileSystem

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenRenewer
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenRenewer
@@ -13,5 +13,5 @@
 #
 org.apache.hadoop.hdfs.DFSClient$Renewer
 org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier$Renewer
-org.apache.hadoop.hdfs.HftpFileSystem$TokenManager
+org.apache.hadoop.hdfs.web.HftpFileSystem$TokenManager
 org.apache.hadoop.hdfs.web.WebHdfsFileSystem$DtRenewer

--- a/hadoop-hdfs-project/hadoop-hdfs/src/site/apt/Hftp.apt.vm
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/site/apt/Hftp.apt.vm
@@ -44,8 +44,8 @@ HFTP Guide
 * Implementation
 
    The code for HFTP lives in the Java class
-   <<<org.apache.hadoop.hdfs.HftpFileSystem>>>. Likewise, HSFTP is implemented
-   in <<<org.apache.hadoop.hdfs.HsftpFileSystem>>>.
+   <<<org.apache.hadoop.hdfs.web.HftpFileSystem>>>. Likewise, HSFTP is implemented
+   in <<<org.apache.hadoop.hdfs.web.HsftpFileSystem>>>.
 
 * Configuration Options
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/aop/org/apache/hadoop/hdfs/TestFiHftp.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/aop/org/apache/hadoop/hdfs/TestFiHftp.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.FSDataset;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.log4j.Level;
 import org.junit.Assert;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/erasure_coding/MockEncodingManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/erasure_coding/MockEncodingManager.java
@@ -33,7 +33,8 @@ public class MockEncodingManager extends EncodingManager {
   }
 
   @Override
-  public void encodeFile(EncodingPolicy encodingPolicy, Path path, Path path1) {
+  public void encodeFile(EncodingPolicy encodingPolicy, Path path, Path path1,
+      boolean copy) {
 
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.apache.hadoop.hdfs.server.protocol.NamenodeProtocols;
 import org.apache.hadoop.hdfs.tools.DFSAdmin;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetUtils;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDistributedFileSystem.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.VolumeId;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.DataChecksum;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileStatus.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileStatus.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.hdfs.server.namenode.FSNamesystem;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Level;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestListPathServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestListPathServlet.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.server.namenode.ListPathsServlet;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestAuditLogs.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.hdfs.HftpFileSystem;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
 import org.apache.hadoop.hdfs.web.WebHdfsTestUtil;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestByteRangeInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestByteRangeInputStream.java
@@ -15,9 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import org.apache.hadoop.hdfs.server.namenode.StreamFile;
+import org.apache.hadoop.hdfs.web.ByteRangeInputStream;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestHftpDelegationToken.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestHftpDelegationToken.java
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
+import org.apache.hadoop.hdfs.web.HsftpFileSystem;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.SecurityUtilTestHelper;
 import org.apache.hadoop.security.UserGroupInformation;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestHftpFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestHftpFileSystem.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import org.apache.commons.logging.impl.Log4JLogger;
 import org.apache.hadoop.conf.Configuration;
@@ -26,9 +26,13 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
 import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
+import org.apache.hadoop.hdfs.web.HsftpFileSystem;
 import org.apache.hadoop.util.ServletUtil;
 import org.apache.log4j.Level;
 import org.junit.After;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestHftpURLTimeouts.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/web/TestHftpURLTimeouts.java
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdfs;
+package org.apache.hadoop.hdfs.web;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.web.HftpFileSystem;
+import org.apache.hadoop.hdfs.web.HsftpFileSystem;
 import org.apache.hadoop.hdfs.web.URLUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/resources/job_1329348432655_0001_conf.xml
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/test/resources/job_1329348432655_0001_conf.xml
@@ -182,7 +182,7 @@
 <property><!--Loaded from job.xml--><name>file.stream-buffer-size</name><value>4096</value></property>
 <property><!--Loaded from job.xml--><name>dfs.namenode.fs-limits.max-directory-items</name><value>0</value></property>
 <property><!--Loaded from job.xml--><name>io.mapfile.bloom.size</name><value>1048576</value></property>
-<property><!--Loaded from job.xml--><name>fs.hsftp.impl</name><value>org.apache.hadoop.hdfs.HsftpFileSystem</value></property>
+<property><!--Loaded from job.xml--><name>fs.hsftp.impl</name><value>org.apache.hadoop.hdfs.web.HsftpFileSystem</value></property>
 <property><!--Loaded from job.xml--><name>yarn.nodemanager.container-executor.class</name><value>org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor</value></property>
 <property><!--Loaded from job.xml--><name>mapreduce.map.maxattempts</name><value>4</value></property>
 <property><!--Loaded from job.xml--><name>mapreduce.jobtracker.jobhistory.block.size</name><value>3145728</value></property>
@@ -224,7 +224,7 @@
 <property><!--Loaded from job.xml--><name>hadoop.http.authentication.simple.anonymous.allowed</name><value>true</value></property>
 <property><!--Loaded from job.xml--><name>hadoop.rpc.socket.factory.class.default</name><value>org.apache.hadoop.net.StandardSocketFactory</value></property>
 <property><!--Loaded from job.xml--><name>mapreduce.job.submithostname</name><value>localhost</value></property>
-<property><!--Loaded from job.xml--><name>fs.hftp.impl</name><value>org.apache.hadoop.hdfs.HftpFileSystem</value></property>
+<property><!--Loaded from job.xml--><name>fs.hftp.impl</name><value>org.apache.hadoop.hdfs.web.HftpFileSystem</value></property>
 <property><!--Loaded from job.xml--><name>dfs.namenode.handler.count</name><value>10</value></property>
 <property><!--Loaded from job.xml--><name>fs.automatic.close</name><value>true</value></property>
 <property><!--Loaded from job.xml--><name>fs.kfs.impl</name><value>org.apache.hadoop.fs.kfs.KosmosFileSystem</value></property>

--- a/hops-erasure-coding/pom.xml
+++ b/hops-erasure-coding/pom.xml
@@ -29,6 +29,12 @@
       <version>20140107</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
     <!-->Test dependencies</-->
     <dependency>
       <groupId>junit</groupId>

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
@@ -23,10 +23,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSOutputStream;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.StringUtils;
@@ -144,14 +147,17 @@ public abstract class BaseEncodingManager extends EncodingManager {
    * RAID a list of files / directories
    */
   void doRaid(Configuration conf, PolicyInfo info) throws IOException {
-    int targetRepl = Integer.parseInt(info.getProperty("targetReplication"));
-    int metaRepl = Integer.parseInt(info.getProperty("metaReplication"));
+    int targetRepl = Integer.parseInt(info.getProperty(
+        PolicyInfo.PROPERTY_REPLICATION));
+    int metaRepl = Integer.parseInt(info.getProperty(
+        PolicyInfo.PROPERTY_PARITY_REPLICATION));
     Codec codec = Codec.getCodec(info.getCodecId());
     Path destPref = new Path(codec.parityDirectory);
+    boolean copy = Boolean.valueOf(info.getProperty(PolicyInfo.PROPERTY_COPY));
 
     Statistics statistics = new Statistics();
     doRaid(conf, info.getSrcPath(), destPref, codec, statistics,
-        RaidUtils.NULL_PROGRESSABLE, targetRepl, metaRepl);
+        RaidUtils.NULL_PROGRESSABLE, targetRepl, metaRepl, copy);
     LOG.info("RAID statistics " + statistics.toString());
   }
 
@@ -161,24 +167,27 @@ public abstract class BaseEncodingManager extends EncodingManager {
    */
   static public boolean doRaid(Configuration conf, PolicyInfo info, Path src,
       Statistics statistics, Progressable reporter) throws IOException {
-    int targetRepl = Integer.parseInt(info.getProperty("targetReplication"));
-    int metaRepl = Integer.parseInt(info.getProperty("metaReplication"));
-
+    int targetRepl = Integer.parseInt(info.getProperty(
+        PolicyInfo.PROPERTY_REPLICATION));
+    int metaRepl = Integer.parseInt(info.getProperty(
+        PolicyInfo.PROPERTY_PARITY_REPLICATION));
     Codec codec = Codec.getCodec(info.getCodecId());
-    Path parityPath = new Path(info.getProperty("parityPath"));
+    Path parityPath = new Path(info.getProperty(
+        PolicyInfo.PROPERTY_PARITY_PATH));
+    boolean copy = Boolean.valueOf(info.getProperty(PolicyInfo.PROPERTY_COPY));
 
     return doRaid(conf, src, parityPath, codec, statistics, reporter,
-        targetRepl, metaRepl);
+        targetRepl, metaRepl, copy);
   }
   
   public static boolean doRaid(Configuration conf, Path path, Path parityPath,
       Codec codec, Statistics statistics, Progressable reporter, int targetRepl,
-      int metaRepl) throws IOException {
+      int metaRepl, boolean copy) throws IOException {
     long startTime = System.currentTimeMillis();
     boolean success = false;
     try {
       return doFileRaid(conf, path, parityPath, codec, statistics, reporter,
-          targetRepl, metaRepl);
+          targetRepl, metaRepl, copy);
     } catch (IOException ioe) {
       throw ioe;
     } finally {
@@ -214,7 +223,8 @@ public abstract class BaseEncodingManager extends EncodingManager {
    */
   public static boolean doFileRaid(Configuration conf, Path sourceFile,
       Path parityPath, Codec codec, Statistics statistics,
-      Progressable reporter, int targetRepl, int metaRepl) throws IOException {
+      Progressable reporter, int targetRepl, int metaRepl, boolean copy)
+      throws IOException {
     FileSystem srcFs = sourceFile.getFileSystem(conf);
     FileStatus sourceStatus = srcFs.getFileStatus(sourceFile);
 
@@ -234,17 +244,36 @@ public abstract class BaseEncodingManager extends EncodingManager {
     statistics.numProcessedBlocks += locations.length;
     statistics.processedSize += diskSpace;
 
-    // generate parity file
-    generateParityFile(conf, sourceStatus, targetRepl, reporter, srcFs,
-        parityPath, codec, locations.length, sourceStatus.getReplication(),
-        metaRepl, sourceStatus.getBlockSize());
-    if (srcFs.setReplication(sourceFile, (short) targetRepl) == false) {
-      LOG.info("Error in reducing replication of " + sourceFile + " to " +
-          targetRepl);
-      statistics.remainingSize += diskSpace;
-      return false;
+    Path tmpFile = null;
+    FSDataOutputStream out = null;
+    try {
+      if (copy) {
+        tmpFile = new Path("/tmp" + sourceFile);
+        out = srcFs.create(tmpFile, (short) targetRepl);
+        DFSOutputStream dfsOut = (DFSOutputStream) out.getWrappedStream();
+        dfsOut.enableSourceStream(codec.getStripeLength());
+      }
+
+      // generate parity file
+      generateParityFile(conf, sourceStatus, reporter, srcFs, parityPath, codec,
+          metaRepl, sourceStatus.getBlockSize(), tmpFile, out);
+
+      if (copy) {
+        out.close();
+        ((DistributedFileSystem) srcFs).rename(tmpFile, sourceFile,
+            Options.Rename.OVERWRITE, Options.Rename.KEEP_ENCODING_STATUS);
+      } else if (srcFs.setReplication(sourceFile, (short) targetRepl) == false) {
+        LOG.info("Error in reducing replication of " + sourceFile + " to " +
+            targetRepl);
+        statistics.remainingSize += diskSpace;
+        return false;
+      }
+    } catch (IOException e) {
+      if (out != null) {
+        out.close();
+      }
+      throw e;
     }
-    ;
 
     diskSpace = 0;
     for (BlockLocation l : locations) {
@@ -270,26 +299,11 @@ public abstract class BaseEncodingManager extends EncodingManager {
    * Generate parity file
    */
   static private void generateParityFile(Configuration conf,
-      FileStatus sourceFile, int targetRepl, Progressable reporter,
-      FileSystem inFs, Path destPath, Codec codec, long blockNum, int srcRepl,
-      int metaRepl, long blockSize) throws IOException {
+      FileStatus sourceFile, Progressable reporter, FileSystem inFs,
+      Path destPath, Codec codec, int metaRepl, long blockSize,
+      Path copyPath, FSDataOutputStream copy) throws IOException {
     Path inpath = sourceFile.getPath();
     FileSystem outFs = inFs;
-
-    // If the parity file is already upto-date and source replication is set
-    // then nothing to do.
-    try {
-      FileStatus stmp = outFs.getFileStatus(destPath);
-      if (stmp.getModificationTime() == sourceFile.getModificationTime() &&
-          srcRepl == targetRepl) {
-        LOG.info("Parity file for " + inpath + "(" + blockNum +
-            ") is " + destPath + " already upto-date and " +
-            "file is at target replication . Nothing more to do.");
-        return;
-      }
-    } catch (IOException e) {
-      // ignore errors because the raid file might not exist yet.
-    }
 
     Encoder encoder = new Encoder(conf, codec);
     FileStatus srcStat = inFs.getFileStatus(inpath);
@@ -302,28 +316,10 @@ public abstract class BaseEncodingManager extends EncodingManager {
     StripeReader sReader =
         new FileStripeReader(conf, blockSize, codec, inFs, 0, inpath, srcSize);
     encoder.encodeFile(conf, inFs, inpath, outFs, destPath, (short) metaRepl,
-        numStripes, blockSize, reporter, sReader);
-
-    // set the modification time of the RAID file. This is done so that the modTime of the
-    // RAID file reflects that contents of the source file that it has RAIDed. This should
-    // also work for files that are being appended to. This is necessary because the time on
-    // on the destination namenode may not be synchronised with the timestamp of the 
-    // source namenode.
-    outFs.setTimes(destPath, sourceFile.getModificationTime(), -1);
+        numStripes, blockSize, reporter, sReader, copyPath, copy);
 
     FileStatus outstat = outFs.getFileStatus(destPath);
     FileStatus inStat = inFs.getFileStatus(inpath);
-    if (sourceFile.getModificationTime() != inStat.getModificationTime()) {
-      String msg = "Source file changed mtime during raiding from " +
-          sourceFile.getModificationTime() + " to " +
-          inStat.getModificationTime();
-      throw new IOException(msg);
-    }
-    if (outstat.getModificationTime() != inStat.getModificationTime()) {
-      String msg = "Parity file mtime " + outstat.getModificationTime() +
-          " does not match source mtime " + inStat.getModificationTime();
-      throw new IOException(msg);
-    }
     LOG.info("Source file " + inpath + " of size " + inStat.getLen() +
         " Parity file " + destPath + " of size " + outstat.getLen() +
         " src mtime " + sourceFile.getModificationTime() +

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
@@ -54,7 +54,6 @@ public class Encoder {
   protected ErasureCode code;
   protected Random rand;
   protected int bufSize;
-  protected byte[][] readBufs;
   protected byte[][] writeBufs;
 
   /**
@@ -117,7 +116,8 @@ public class Encoder {
    */
   public void encodeFile(Configuration jobConf, FileSystem fs, Path srcFile,
       FileSystem parityFs, Path parityFile, short parityRepl, long numStripes,
-      long blockSize, Progressable reporter, StripeReader sReader)
+      long blockSize, Progressable reporter, StripeReader sReader,
+      Path copyPath, FSDataOutputStream copy)
       throws IOException {
     long expectedParityBlocks = numStripes * codec.parityLength;
     long expectedParityFileSize = numStripes * blockSize * codec.parityLength;
@@ -141,17 +141,16 @@ public class Encoder {
         tmpRepl = 2;
       }
     }
-    FSDataOutputStream out = parityFs
-        .create(parityFile, true, conf.getInt("io.file.buffer.size", 64 * 1024),
-            tmpRepl, blockSize);
+    FSDataOutputStream out = parityFs.create(parityFile, true,
+        conf.getInt("io.file.buffer.size", 64 * 1024), tmpRepl, blockSize);
 
     DFSOutputStream dfsOut = (DFSOutputStream) out.getWrappedStream();
     dfsOut.enableParityStream(codec.getStripeLength(), codec.getParityLength(),
-        srcFile.toUri().getPath());
+        copy == null ? srcFile.toUri().getPath() : null);
 
     try {
       encodeFileToStream(fs, srcFile, parityFile, sReader, blockSize, out,
-          reporter);
+          reporter, copyPath, copy);
       out.close();
       out = null;
       LOG.info("Wrote parity file " + parityFile);
@@ -278,8 +277,9 @@ public class Encoder {
    *     The destination for the reovered block.
    */
   private void encodeFileToStream(FileSystem fs, Path sourceFile,
-      Path parityFile, StripeReader sReader, long blockSize, OutputStream out,
-      Progressable reporter) throws IOException {
+      Path parityFile, StripeReader sReader, long blockSize,
+      FSDataOutputStream out, Progressable reporter,
+      Path copyPath, FSDataOutputStream copy) throws IOException {
     OutputStream[] tmpOuts = new OutputStream[codec.parityLength];
     // One parity block can be written directly to out, rest to local files.
     tmpOuts[0] = out;
@@ -289,6 +289,20 @@ public class Encoder {
       LOG.info("Created tmp file " + tmpFiles[i]);
       tmpFiles[i].deleteOnExit();
     }
+
+    OutputStream[] copyOuts = null;
+    File[] tmpCopyFiles = null;
+    if (copy != null) {
+      copyOuts = new OutputStream[codec.stripeLength];
+      tmpCopyFiles = new File[codec.stripeLength];
+      for (int i = 0; i < codec.stripeLength; i++) {
+        tmpCopyFiles[i] = File.createTempFile("copy", "_" + i);
+        LOG.info("Created tmp file " + tmpCopyFiles[i]);
+        tmpCopyFiles[i].deleteOnExit();
+        copyOuts[i] = new FileOutputStream(tmpCopyFiles[i]);
+      }
+    }
+
     try {
       // Loop over stripe
       int stripe = 0;
@@ -303,7 +317,7 @@ public class Encoder {
           }
           // Call the implementation of encoding.
           encodeStripe(fs, sourceFile, parityFile, blocks, blockSize, tmpOuts,
-              reporter, true, stripe);
+              reporter, true, stripe, copyPath, copyOuts);
           stripe++;
         } finally {
           RaidUtils.closeStreams(blocks);
@@ -317,6 +331,21 @@ public class Encoder {
           RaidUtils.copyBytes(in, out, writeBufs[i], blockSize);
           reporter.progress();
         }
+        if (copy != null) {
+          out.hflush();
+          DFSOutputStream sourceOut = (DFSOutputStream) copy.getWrappedStream();
+          DFSOutputStream parityOut = (DFSOutputStream) out.getWrappedStream();
+          sourceOut.setParityStripeNodesForNextStripe(parityOut.getUsedNodes());
+        }
+        if (copyOuts != null) {
+          for (int i = 0; i < codec.stripeLength; i++) {
+            copyOuts[i].close();
+            copyOuts[i] = null;
+            InputStream in = new FileInputStream(tmpCopyFiles[i]);
+            RaidUtils.copyBytes(in, copy, writeBufs[0], blockSize);
+            reporter.progress();
+          }
+        }
       }
     } finally {
       for (int i = 0; i < codec.parityLength - 1; i++) {
@@ -326,6 +355,15 @@ public class Encoder {
         tmpFiles[i].delete();
         LOG.info("Deleted tmp file " + tmpFiles[i]);
       }
+      if (copyOuts != null) {
+        for (int i = 0; i < codec.stripeLength; i++) {
+          if (copyOuts[i] != null) {
+            copyOuts[i].close();
+          }
+          tmpCopyFiles[i].delete();
+          LOG.info("Deleted tmp file " + tmpCopyFiles[i]);
+        }
+      }
     }
   }
 
@@ -333,7 +371,7 @@ public class Encoder {
       InputStream[] blocks, long blockSize, OutputStream[] outs,
       Progressable reporter) throws IOException {
     encodeStripe(fs, sourceFile, parityFile, blocks, blockSize, outs, reporter,
-        false, 0);
+        false, 0, null, null);
   }
 
   /**
@@ -344,8 +382,8 @@ public class Encoder {
    */
   void encodeStripe(FileSystem fs, Path sourceFile, Path parityFile,
       InputStream[] blocks, long blockSize, OutputStream[] outs,
-      Progressable reporter, boolean computeBlockChecksum, int stripe)
-      throws IOException {
+      Progressable reporter, boolean computeBlockChecksum, int stripe,
+      Path copyPath, OutputStream[] copyOuts) throws IOException {
     configureBuffers(blockSize);
     int boundedBufferCapacity = 1;
     ParallelStreamReader parallelReader =
@@ -382,6 +420,11 @@ public class Encoder {
         if (computeBlockChecksum) {
           updateChecksums(sourceChecksums, readResult.readBufs);
         }
+        if (copyOuts != null) {
+          for (int i = 0; i < readResult.readBufs.length; i++) {
+            copyOuts[i].write(readResult.readBufs[i], 0, readResult.numRead[i]);
+          }
+        }
         code.encodeBulk(readResult.readBufs, writeBufs);
         reporter.progress();
 
@@ -394,8 +437,9 @@ public class Encoder {
           reporter.progress();
         }
       }
-      sendChecksums((DistributedFileSystem) fs, sourceFile, sourceChecksums,
-          stripe, codec.stripeLength);
+      sendChecksums((DistributedFileSystem) fs,
+          copyPath == null ? sourceFile : copyPath,
+          sourceChecksums, stripe, codec.stripeLength);
       sendChecksums((DistributedFileSystem) fs, parityFile, parityChecksums,
           stripe, codec.parityLength);
     } finally {

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/LocalEncodingManager.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/LocalEncodingManager.java
@@ -45,7 +45,7 @@ public class LocalEncodingManager extends BaseEncodingManager {
 
   @Override
   public void encodeFile(EncodingPolicy policy, Path sourceFile,
-      Path parityFile) {
+      Path parityFile, boolean copy) {
     if (!initialized) {
       try {
         cleanUpTempDirectory(conf);
@@ -60,11 +60,13 @@ public class LocalEncodingManager extends BaseEncodingManager {
     try {
       policyInfo.setSrcPath(sourceFile.toUri().getPath());
       policyInfo.setCodecId(codec.getId());
-      policyInfo.setProperty("parityPath", parityFile.toUri().getPath());
-      policyInfo.setProperty("targetReplication",
+      policyInfo.setProperty(PolicyInfo.PROPERTY_PARITY_PATH,
+          parityFile.toUri().getPath());
+      policyInfo.setProperty(PolicyInfo.PROPERTY_REPLICATION,
           String.valueOf(policy.getTargetReplication()));
-      policyInfo.setProperty("metaReplication",
-          String.valueOf(policy.getTargetReplication()));
+      policyInfo.setProperty(PolicyInfo.PROPERTY_PARITY_REPLICATION,
+          String.valueOf(1));
+      policyInfo.setProperty(PolicyInfo.PROPERTY_COPY, String.valueOf(copy));
       doRaid(conf, policyInfo);
     } catch (IOException e) {
       LOG.error("Exception", e);

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/MapReduceEncodingManager.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/MapReduceEncodingManager.java
@@ -59,7 +59,7 @@ public class MapReduceEncodingManager extends BaseEncodingManager {
 
   @Override
   public void encodeFile(EncodingPolicy policy, Path sourceFile,
-      Path parityFile) {
+      Path parityFile, boolean copy) {
     if (!initialized) {
       try {
         cleanUpTempDirectory(conf);
@@ -71,16 +71,19 @@ public class MapReduceEncodingManager extends BaseEncodingManager {
 
     Codec codec = Codec.getCodec(policy.getCodec());
     LOG.info("Start encoding with policy: " + policy + " for source file " +
-        sourceFile.toUri().getPath() + " and parity file " + parityFile);
+        sourceFile.toUri().getPath() + " and parity file " + parityFile +
+        " copy " + copy);
     PolicyInfo policyInfo = new PolicyInfo();
     try {
-      // This is somewhat redundant with the list below
       policyInfo.setSrcPath(sourceFile.toUri().getPath());
       policyInfo.setCodecId(codec.getId());
-      policyInfo.setProperty("parityPath", parityFile.toUri().getPath());
-      policyInfo.setProperty("targetReplication",
+      policyInfo.setProperty(PolicyInfo.PROPERTY_PARITY_PATH,
+          parityFile.toUri().getPath());
+      policyInfo.setProperty(PolicyInfo.PROPERTY_REPLICATION,
           String.valueOf(policy.getTargetReplication()));
-      policyInfo.setProperty("metaReplication", String.valueOf(1));
+      policyInfo.setProperty(PolicyInfo.PROPERTY_PARITY_REPLICATION,
+          String.valueOf(1));
+      policyInfo.setProperty(PolicyInfo.PROPERTY_COPY, String.valueOf(copy));
       raidFiles(policyInfo);
     } catch (IOException e) {
       LOG.error("Exception", e);

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/PolicyInfo.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/PolicyInfo.java
@@ -49,6 +49,11 @@ class PolicyInfo implements Writable {
   private String description;      // A verbose description of this policy
   private Configuration conf;      // Hadoop configuration
 
+  public static String PROPERTY_PARITY_PATH = "parityPath";
+  public static String PROPERTY_REPLICATION = "targetReplication";
+  public static String PROPERTY_PARITY_REPLICATION = "metaReplication";
+  public static String PROPERTY_COPY = "copy";
+
   private Properties properties;   // Policy-dependent properties
 
   /**

--- a/hops-erasure-coding/src/test/java/io/hops/erasure_coding/ClusterTest.java
+++ b/hops-erasure-coding/src/test/java/io/hops/erasure_coding/ClusterTest.java
@@ -43,15 +43,7 @@ public abstract class ClusterTest extends TestCase {
 
   @Override
   public void tearDown() throws Exception {
-    try {
-      FileStatus[] files = fs.globStatus(new Path("/*"));
-      for (FileStatus file : files) {
-        fs.delete(file.getPath(), true);
-      }
-      fs.close();
-    } finally {
-      cluster.shutdown();
-    }
+    cluster.shutdown();
   }
 
   public FileSystem getFileSystem() {

--- a/hops-erasure-coding/src/test/java/io/hops/erasure_coding/TestLocalEncodingManagerImpl.java
+++ b/hops-erasure-coding/src/test/java/io/hops/erasure_coding/TestLocalEncodingManagerImpl.java
@@ -69,9 +69,8 @@ public class TestLocalEncodingManagerImpl extends ClusterTest {
 
     Codec codec = Util.getCodec(Util.Codecs.SRC);
     BaseEncodingManager.Statistics stats = new BaseEncodingManager.Statistics();
-    assertTrue(encodingManager
-        .doFileRaid(conf, testFile, parityFile, codec, stats,
-            RaidUtils.NULL_PROGRESSABLE, 1, 1));
+    assertTrue(encodingManager.doFileRaid(conf, testFile, parityFile, codec,
+        stats, RaidUtils.NULL_PROGRESSABLE, 1, 1, false));
     try {
       dfs.open(parityFile);
     } catch (IOException e) {

--- a/hops-erasure-coding/src/test/java/io/hops/erasure_coding/TestMapReduceBlockRepairManager.java
+++ b/hops-erasure-coding/src/test/java/io/hops/erasure_coding/TestMapReduceBlockRepairManager.java
@@ -79,7 +79,7 @@ public class TestMapReduceBlockRepairManager extends ClusterTest {
     Codec.initializeCodecs(conf);
     FileStatus testFileStatus = dfs.getFileStatus(testFile);
     EncodingPolicy policy = new EncodingPolicy("src", (short) 1);
-    encodingManager.encodeFile(policy, testFile, parityFile);
+    encodingManager.encodeFile(policy, testFile, parityFile, false);
 
     // Busy waiting until the encoding is done
     while (encodingManager.computeReports().size() > 0) {
@@ -137,7 +137,7 @@ public class TestMapReduceBlockRepairManager extends ClusterTest {
     Codec.initializeCodecs(conf);
     FileStatus testFileStatus = dfs.getFileStatus(testFile);
     EncodingPolicy policy = new EncodingPolicy("src", (short) 1);
-    encodingManager.encodeFile(policy, testFile, parityFile);
+    encodingManager.encodeFile(policy, testFile, parityFile, false);
 
     // Busy waiting until the encoding is done
     while (encodingManager.computeReports().size() > 0) {

--- a/hops-erasure-coding/src/test/java/io/hops/erasure_coding/Util.java
+++ b/hops-erasure-coding/src/test/java/io/hops/erasure_coding/Util.java
@@ -101,9 +101,8 @@ public class Util {
     LocalEncodingManager encodingManager = new LocalEncodingManager(conf);
 
     BaseEncodingManager.Statistics stats = new BaseEncodingManager.Statistics();
-    return encodingManager
-        .doFileRaid(conf, sourceFile, parityPath, codec, stats,
-            RaidUtils.NULL_PROGRESSABLE, 1, 1);
+    return encodingManager.doFileRaid(conf, sourceFile, parityPath, codec,
+        stats, RaidUtils.NULL_PROGRESSABLE, 1, 1, false);
   }
 
   public static Codec getCodec(Codecs codec) {


### PR DESCRIPTION
Add the ability to rewrite files to be erasure-coded in the mapper instead of the client.
Previously, files needed to be read and rewritten by a client when requesting an encoding for an existing file.
This commit makes the calls asynchronously for the client and saves one read of the file as it is rewritten while being read for the actual encoding.

resolve #17 