### PR TITLE
Make the erasure coding components work when the ErasureCodingFileSystem is configured as default

### DIFF
--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
@@ -21,6 +21,7 @@ package io.hops.erasure_coding;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.ErasureCodingFileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -441,11 +442,13 @@ public class Encoder {
           reporter.progress();
         }
       }
-      sendChecksums((DistributedFileSystem) fs,
-          copyPath == null ? sourceFile : copyPath,
+      DistributedFileSystem dfs =(DistributedFileSystem)
+          (fs instanceof ErasureCodingFileSystem ?
+              ((ErasureCodingFileSystem) fs).getFileSystem() : fs);
+      sendChecksums(dfs, copyPath == null ? sourceFile : copyPath,
           sourceChecksums, stripe, codec.stripeLength);
-      sendChecksums((DistributedFileSystem) fs, parityFile, parityChecksums,
-          stripe, codec.parityLength);
+      sendChecksums(dfs, parityFile, parityChecksums, stripe,
+          codec.parityLength);
     } finally {
       parallelReader.shutdown();
     }

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Helper.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Helper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.erasure_coding;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.ErasureCodingFileSystem;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
+import java.io.IOException;
+
+public class Helper {
+
+  public static DistributedFileSystem getDFS(Configuration conf, Path path)
+      throws IOException {
+    FileSystem fs = path.getFileSystem(conf);
+    DistributedFileSystem dfs =(DistributedFileSystem)
+        (fs instanceof ErasureCodingFileSystem ?
+            ((ErasureCodingFileSystem) fs).getFileSystem() : fs);
+    return dfs;
+  }
+}

--- a/hops-erasure-coding/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReconstructor.java
+++ b/hops-erasure-coding/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReconstructor.java
@@ -19,12 +19,15 @@
 package org.apache.hadoop.hdfs.server.datanode;
 
 import io.hops.erasure_coding.Decoder;
+import io.hops.erasure_coding.Helper;
 import io.hops.erasure_coding.RaidUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.ErasureCodingFileSystem;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
@@ -60,16 +63,9 @@ public class BlockReconstructor extends Configured {
         conf.getInt(SEND_BLOCK_RETRY_COUNT_KEY, DEFAULT_SEND_BLOCK_RETRY_COUNT);
   }
 
-  /**
-   * Returns a DistributedFileSystem hosting the path supplied.
-   */
-  public DistributedFileSystem getDFS(Path p) throws IOException {
-    return (DistributedFileSystem) p.getFileSystem(getConf());
-  }
-
   public boolean processFile(Path sourceFile, Path parityFile, Decoder decoder)
       throws IOException, InterruptedException {
-    DFSClient dfsClient = getDFS(sourceFile).getClient();
+    DFSClient dfsClient = Helper.getDFS(getConf(), sourceFile).getClient();
     LocatedBlocks missingBlocks =
         dfsClient.getMissingLocatedBlocks(sourceFile.toUri().getPath());
     return processFile(sourceFile, parityFile, missingBlocks, decoder, null);
@@ -84,9 +80,9 @@ public class BlockReconstructor extends Configured {
       progress = RaidUtils.NULL_PROGRESSABLE;
     }
 
-    DistributedFileSystem srcFs = getDFS(sourceFile);
+    DistributedFileSystem srcFs = Helper.getDFS(getConf(), sourceFile);
     FileStatus sourceStatus = srcFs.getFileStatus(sourceFile);
-    DistributedFileSystem parityFs = getDFS(parityFile);
+    DistributedFileSystem parityFs = Helper.getDFS(getConf(), parityFile);
     long blockSize = sourceStatus.getBlockSize();
     long srcFileSize = sourceStatus.getLen();
     String uriPath = sourceFile.toUri().getPath();
@@ -134,7 +130,7 @@ public class BlockReconstructor extends Configured {
   public boolean processParityFile(Path sourceFile, Path parityFile,
       Decoder decoder, Context context)
       throws IOException, InterruptedException {
-    DFSClient dfsClient = getDFS(sourceFile).getClient();
+    DFSClient dfsClient = Helper.getDFS(getConf(), sourceFile).getClient();
     LocatedBlocks missingBlocks =
         dfsClient.getMissingLocatedBlocks(parityFile.toUri().getPath());
     return processParityFile(sourceFile, parityFile, missingBlocks, decoder,
@@ -151,9 +147,9 @@ public class BlockReconstructor extends Configured {
       progress = RaidUtils.NULL_PROGRESSABLE;
     }
 
-    DistributedFileSystem srcFs = getDFS(sourceFile);
+    DistributedFileSystem srcFs = Helper.getDFS(getConf(), sourceFile);
     Path srcPath = sourceFile;
-    DistributedFileSystem parityFs = getDFS(parityFile);
+    DistributedFileSystem parityFs = Helper.getDFS(getConf(), parityFile);
     Path parityPath = parityFile;
     FileStatus parityStat = parityFs.getFileStatus(parityPath);
     long blockSize = parityStat.getBlockSize();

--- a/hops-erasure-coding/src/test/java/io/hops/erasure_coding/ClusterTest.java
+++ b/hops-erasure-coding/src/test/java/io/hops/erasure_coding/ClusterTest.java
@@ -32,10 +32,11 @@ public abstract class ClusterTest extends TestCase {
 
   @Override
   public void setUp() throws Exception {
-    cluster = new MiniDFSCluster.Builder(getConfig()).numDataNodes(numDatanode)
+    Configuration conf = getConfig();
+    cluster = new MiniDFSCluster.Builder(conf).numDataNodes(numDatanode)
         .build();
     cluster.waitActive();
-    fs = cluster.getFileSystem();
+    fs = FileSystem.get(conf);
   }
 
   @Override


### PR DESCRIPTION
Some erasure coding classes were expecting DistributedFileSystem to be used and crashed in case ErasureCodingFileSystem was used. This patch resolves this issue.
