### PR TITLE
resolving foreign key exception when application attempt is completed

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/TransactionStateImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/TransactionStateImpl.java
@@ -69,6 +69,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.apache.hadoop.yarn.server.resourcemanager.recovery.RMStateStore.LOG;
 
@@ -661,8 +663,13 @@ public class TransactionStateImpl extends TransactionState {
       this.ts = ts;
     }
 
+    @Override
     public void run() {
-      RMUtilities.finishRPC(ts, rpcID);
+      try {
+        RMUtilities.finishRPC(ts, rpcID);
+      } catch (IOException ex) {
+        LOG.error(ex,ex);
+      }
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMUtilities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMUtilities.java
@@ -2091,7 +2091,7 @@ public class RMUtilities {
       new HashMap<Integer, TransactionStateImpl>();
   static Lock nextRPCLock = new ReentrantLock();
   
-  public static void finishRPCs(TransactionStateImpl ts, int rpcID) {
+  public static void finishRPCs(TransactionStateImpl ts, int rpcID) throws IOException {
     nextRPCLock.lock();
     LOG.debug("finishing rpc " + rpcID + " " + nextRPC);
     if (rpcID > nextRPC) {
@@ -2113,7 +2113,7 @@ public class RMUtilities {
     }
   }
   
-  public static void finishRPC(final TransactionStateImpl ts, final int rpcID) {
+  public static void finishRPC(final TransactionStateImpl ts, final int rpcID) throws IOException {
 
     LOG.debug("HOP :: finishRPC - START:" + rpcID);
 
@@ -2206,11 +2206,7 @@ public class RMUtilities {
             return null;
           }
         };
-    try {
       setfinishRPCHandler.handle();
-    } catch (IOException ex) {
-      LOG.error("HOP :: Error commiting finishRPC", ex);
-    }
   }
 
   //for testing (todo: move in test class)


### PR DESCRIPTION
Correcting the foreign key exception that sometime happen when an application attempt finish. This foreign key exception was due to the fact that as the application attempt is updated before to be removed and the commit to the database was trying to do the update once the remove was committed.

Solving #55 