### PR TITLE
Fix distributed mode recovery

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -2404,6 +2404,25 @@ public abstract class Server {
           handlers[i].interrupt();
         }
       }
+      for (int i = 0; i < handlerCount; i++) {
+        if (handlers[i] != null) {
+          try {
+            boolean success = false;
+            int nbTry=0;
+            while (!success && nbTry<10) {
+              handlers[i].join(10);
+              if (handlers[i].isAlive()) {
+                LOG.info("server handler not finishing " + i);
+                handlers[i].interrupt();
+              }else{
+                success=true;
+              }
+            }
+          } catch (InterruptedException ex) {
+            LOG.error(ex,ex);
+          }
+        }
+      }
     }
     listener.interrupt();
     listener.doStop();
@@ -2415,6 +2434,7 @@ public abstract class Server {
     if (this.rpcDetailedMetrics != null) {
       this.rpcDetailedMetrics.shutdown();
     }
+    LOG.info("stopped server on " + port);
   }
 
   /** Wait for the server to be stopped.

--- a/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/SLSRunner.java
+++ b/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/SLSRunner.java
@@ -124,10 +124,7 @@ public class SLSRunner implements AMNMCommonObject {
   // logger
   public final static Logger LOG = Logger.getLogger(SLSRunner.class);
 
-  private final String rmAddress;
   private int numberOfRT = 0;
-  private final String[] rtAddresses = new String[5]; // this is kind of fixed,
-  ResourceTracker[] resourceTrackers = new ResourceTracker[5];
 
   private int totalJobRunningTimeSec = 0;
   protected YarnClient rmClient;
@@ -158,15 +155,12 @@ public class SLSRunner implements AMNMCommonObject {
     distributedmode = distributedMode;
     this.loadsimulatormode = loadSimMode;
     if (resourceTrackerAddress.split(",").length == 1) { // so we only have one RT
-      this.rtAddresses[0] = resourceTrackerAddress;
       this.numberOfRT = 1;
     } else {
       for (int i = 0; i < resourceTrackerAddress.split(",").length; ++i) {
-        rtAddresses[i] = resourceTrackerAddress.split(",")[i];
       }
       this.numberOfRT = resourceTrackerAddress.split(",").length;
     }
-    this.rmAddress = resourceManagerAddress;
     this.inputTraces = inputTraces.clone();
     this.nodeFile = nodeFile;
     this.trackedApps = trackedApps;
@@ -206,7 +200,6 @@ public class SLSRunner implements AMNMCommonObject {
 
   public void initializeYarnClientForAMSimulation() {
     YarnConfiguration yarnConf = new YarnConfiguration();
-    yarnConf.setStrings(YarnConfiguration.RM_ADDRESS, rmAddress);
     rmClient = YarnClient.createYarnClient();
     rmClient.init(yarnConf);
     rmClient.start();
@@ -350,7 +343,8 @@ public class SLSRunner implements AMNMCommonObject {
 
   }
 
-  private void startNM() throws YarnException, IOException {
+  private void startNM() throws YarnException, IOException, 
+          ClassNotFoundException {
     // nm configuration
     // 38GB
     nmMemoryMB = conf.getInt(SLSConfiguration.NM_MEMORY_MB,
@@ -371,18 +365,8 @@ public class SLSRunner implements AMNMCommonObject {
       nodeSet.addAll(SLSUtils.parseNodesFromNodeFile(nodeFile));
     }
 
-    Configuration rtConf = new YarnConfiguration();
-    int rtPort = rtConf.getPort(YarnConfiguration.RM_RESOURCE_TRACKER_PORT,
-            YarnConfiguration.DEFAULT_RM_RESOURCE_TRACKER_PORT);
 
     for (int i = 0; i < numberOfRT; ++i) {
-      rtConf.setStrings(YarnConfiguration.RM_RESOURCE_TRACKER_ADDRESS,
-              rtAddresses[i]);
-      resourceTrackers[i] = (ResourceTracker) RpcClientFactoryPBImpl.get().
-              getClient(ResourceTracker.class, 1, rtConf.getSocketAddr(
-                              YarnConfiguration.RM_RESOURCE_TRACKER_ADDRESS,
-                              YarnConfiguration.DEFAULT_RM_RESOURCE_TRACKER_ADDRESS,
-                              rtPort), rtConf);
     }
     // create NM simulators
     int counter = 0;
@@ -395,8 +379,8 @@ public class SLSRunner implements AMNMCommonObject {
       NMSimulator nm = new NMSimulator();
       nm.init(hostName, nmMemoryMB, nmVCores,
               random.nextInt(nmHeartbeatInterval), nmHeartbeatInterval, rm,
-              resourceTrackers[counter % numberOfRT]);
-
+               conf);
+      LOG.info("Inited nm: " + hostName + " (" + counter + ")");
       nmMap.put(nm.getNode().getNodeID(), nm);
       nodeRunner.schedule(nm);
       rackSet.add(nm.getNode().getRackName());
@@ -813,13 +797,12 @@ public class SLSRunner implements AMNMCommonObject {
       }
       FileWriter fileWritter = new FileWriter(file.getName(), true);
       BufferedWriter bufferWritter = new BufferedWriter(fileWritter);
-      bufferWritter.write(simulationDuration + " \t" + rtHBRatio + " ("
-              + rtHbDetail + ")" + " \t"
-              + scHBRatio + " (" + scHbDetail + ")" + " \t"
-              + avgApplicationWaitTime + " \t"
-              + avgContainerAllocationWaitTime + " \t" + avgContainerStartTime
-              + " \t" + nbContainers + " \t" + avgClusterUsage + " \t"
-              + appNotAllocated.get() + " \n");
+      bufferWritter.write(simulationDuration + "\t" + rtHBRatio +/* " ("
+              + rtHbDetail + ")" +*/ "\t"
+              + scHBRatio + /*" (" + scHbDetail + ")" +*/ "\t"
+              + avgApplicationWaitTime + "\t"
+              + avgContainerAllocationWaitTime + "\t" + avgContainerStartTime
+              + "\t" + nbContainers + "\t" + avgClusterUsage + "\n");
       bufferWritter.close();
 
       file = new File("clusterUsageDetail");
@@ -960,7 +943,7 @@ public class SLSRunner implements AMNMCommonObject {
 
   Queue<Integer> clusterUsages = new LinkedBlockingQueue<Integer>();
   float lastClusterUsage = 0;
-
+  
   private class Measurer implements Runnable {
 
     final long xpDuration;

--- a/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/appmaster/AMSimulator.java
+++ b/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/appmaster/AMSimulator.java
@@ -19,9 +19,6 @@ package org.apache.hadoop.distributedloadsimulator.sls.appmaster;
  *
  * @author sri
  */
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -67,8 +64,6 @@ import org.apache.hadoop.distributedloadsimulator.sls.scheduler.ResourceSchedule
 import org.apache.hadoop.distributedloadsimulator.sls.SLSRunner;
 import org.apache.hadoop.distributedloadsimulator.sls.scheduler.TaskRunner;
 import org.apache.hadoop.distributedloadsimulator.sls.utils.SLSUtils;
-import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.ipc.UserIdentityProvider;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SaslRpcServer;
 import org.apache.hadoop.security.SecurityUtil;
@@ -91,9 +86,10 @@ import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.ClientRMProxy;
+import org.apache.hadoop.yarn.client.ConfiguredLeaderFailoverHAProxyProvider;
+import org.apache.hadoop.yarn.client.RMFailoverProxyProvider;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.util.Records;
 
@@ -159,6 +155,10 @@ public abstract class AMSimulator extends TaskRunner.Task {
     super.init(traceStartTime, traceStartTime + 1000000L * heartbeatInterval,
             heartbeatInterval);
     this.conf = conf;
+    conf.setClass(YarnConfiguration.CLIENT_FAILOVER_PROXY_PROVIDER,
+            ConfiguredLeaderFailoverHAProxyProvider.class,
+            RMFailoverProxyProvider.class);
+
     this.user = user;
     this.amId = id;
     this.rm = rm;
@@ -206,15 +206,6 @@ public abstract class AMSimulator extends TaskRunner.Task {
       }
     }
 
-  }
-
-  protected ApplicationMasterProtocol createSchedulerProxy() {
-
-    try {
-      return ClientRMProxy.createRMProxy(conf, ApplicationMasterProtocol.class);
-    } catch (IOException e) {
-      throw new YarnRuntimeException(e);
-    }
   }
 
   /**

--- a/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/scheduler/TaskRunner.java
+++ b/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/scheduler/TaskRunner.java
@@ -87,8 +87,10 @@ public class TaskRunner {
             queue.add(this);          
           }
         } else if (nextRun < endTime) {
+          long start = System.currentTimeMillis();
           middleStep();
-          nextRun = System.currentTimeMillis() + repeatInterval;
+          long duration = System.currentTimeMillis()-start;
+          nextRun = System.currentTimeMillis() + Math.max(repeatInterval-duration,0);
           queue.add(this);
         } else {
           lastStep();

--- a/hadoop-yarn-project/hadoop-yarn/bin/yarn
+++ b/hadoop-yarn-project/hadoop-yarn/bin/yarn
@@ -239,7 +239,7 @@ else
   CLASS=$COMMAND
 fi
 
-YARN_OPTS="$YARN_OPTS -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+#YARN_OPTS="$YARN_OPTS -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
 YARN_OPTS="$YARN_OPTS -Dhadoop.log.dir=$YARN_LOG_DIR"
 YARN_OPTS="$YARN_OPTS -Dyarn.log.dir=$YARN_LOG_DIR"
 YARN_OPTS="$YARN_OPTS -Dhadoop.log.file=$YARN_LOGFILE"

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -427,6 +427,7 @@ public class YarnConfiguration extends Configuration {
   public static final String DISTRIBUTED_RM =
       CLIENT_FAILOVER_PREFIX + "distributed";
   public static final Boolean DEFAULT_DISTRIBUTED_RM = false;
+  //TODO this is the same as CLIENT_FAILOVER_PROXY_PROVIDER on of this should be removed
   public static final String DISTRIBUTED_CLIENT_FAILOVER_PROXY_PROVIDER =
       CLIENT_FAILOVER_PREFIX + "proxy-provider";
   public static final String
@@ -1365,6 +1366,7 @@ public class YarnConfiguration extends Configuration {
   public static final String HOPS_BATCH_MAX_DURATION = HOPS_RM_PREFIX + "batch.max.duration";
   public static int DEFAULT_HOPS_BATCH_MAX_DURATION = 100;
 
+  //TODO why do we need two conf ndb-event-streaming.enable and ndb-rt-event-streaming.enable ?
   //NDB event streaming
   public static boolean DEFAULT_HOPS_NDB_EVENT_STREAMING_ENABLED = false;
   public static final String HOPS_NDB_EVENT_STREAMING_ENABLED = HOPS_RM_PREFIX

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/io/hops/ha/common/TransactionState.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/io/hops/ha/common/TransactionState.java
@@ -28,7 +28,7 @@ public abstract class TransactionState {
 
   //TODO: Should we persist this id when the RT crashes and the NM starts 
   //sending HBs to the new RT?
-  protected static AtomicInteger pendingEventId = new AtomicInteger(0);
+  protected final static AtomicInteger pendingEventId = new AtomicInteger(0);
 
   public enum TransactionType {
 
@@ -43,7 +43,7 @@ public abstract class TransactionState {
   protected final Set<ApplicationId> appIds = new ConcurrentSkipListSet<ApplicationId>();
 //  private final Lock counterLock = new ReentrantLock(true);
   private Set<Integer> rpcIds = new ConcurrentSkipListSet<Integer>();
-  private int id=-1;
+  private AtomicInteger id=new AtomicInteger(-1);
   private final boolean batch;
 
   public TransactionState(int initialCounter, boolean batch) {
@@ -53,7 +53,7 @@ public abstract class TransactionState {
   }
 
   public int getId(){
-    return id;
+    return id.get();
   }
     public Set<ApplicationId> getAppIds(){
     return appIds;
@@ -77,8 +77,8 @@ public abstract class TransactionState {
   }
 
   public void addRPCId(int rpcId){
-    if(rpcId>=0 && id<0){
-      id = rpcId;
+    if(rpcId>=0){
+      id.compareAndSet(-1, rpcId);
     }
     rpcIds.add(rpcId);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/io/hops/yarn/groupMembership/SortedActiveRMList.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/io/hops/yarn/groupMembership/SortedActiveRMList.java
@@ -59,14 +59,22 @@ public class SortedActiveRMList {
 
   public ActiveNode getLeastLoaded() {
     List<ActiveNode> rms = activeNodes.getActiveNodes();
-    ActiveRM result =
-        new ActiveRMPBImpl(((ActiveNodePBImpl) rms.get(0)).getProto());
-    for (ActiveNode node : rms) {
-      ActiveRM rm = new ActiveRMPBImpl(((ActiveNodePBImpl) node).getProto());
-      if (rm.getLoad() < result.getLoad() ||
-          (rm.getLoad() == result.getLoad() && random.nextBoolean())) {
-        result = rm;
+    ActiveNode leader = activeNodes.getLeader();
+    ActiveRM result = null;
+    if (rms.size() > 1) {
+      for (ActiveNode node : rms) {
+        ActiveRM rm = new ActiveRMPBImpl(((ActiveNodePBImpl) node).getProto());
+        if (!rm.getHostname().equals(leader.getHostname())) {
+          if (result == null) {
+            result = rm;
+          } else if (rm.getLoad() < result.getLoad() || (rm.getLoad() == result.
+                  getLoad() && random.nextBoolean())) {
+            result = rm;
+          }
+        }
       }
+    } else {
+      result = new ActiveRMPBImpl(((ActiveNodePBImpl) rms.get(0)).getProto());
     }
     return result;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/GroupMembershipProxyService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/client/GroupMembershipProxyService.java
@@ -30,11 +30,16 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.exceptions.YarnException;
 
 public class GroupMembershipProxyService implements Closeable {
 
@@ -93,22 +98,45 @@ public class GroupMembershipProxyService implements Closeable {
     while (!anList.isEmpty()) {
       List<ActiveNode> activeNodes = anList.getActiveNodes();
 
-      ActiveNode nextNode = activeNodes.get(random.nextInt(activeNodes.size()));
+      final ActiveNode nextNode = activeNodes.get(random.nextInt(activeNodes.
+              size()));
       try {
-        GroupMembership proxy = oldProxies.get(nextNode.getInetSocketAddress());
-        if (proxy == null) {
-          proxy = new GroupMembershipPBClientImpl(1,
-              nextNode.getInetSocketAddress(), conf);
-          oldProxies.put(nextNode.getInetSocketAddress(), proxy);
-        }
 
-        LiveRMsResponse response = proxy.getLiveRMList();
+        UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+        if (ugi.getRealUser() != null) {
+          ugi = ugi.getRealUser();
+        }
+        LiveRMsResponse response = ugi
+                .doAs(new PrivilegedAction<LiveRMsResponse>() {
+                  @Override
+                  public LiveRMsResponse run() {
+                    try {
+                      GroupMembership proxy = oldProxies.get(nextNode.
+                              getInetSocketAddress());
+                      if (proxy == null) {
+                        proxy = new GroupMembershipPBClientImpl(1,
+                                nextNode.getInetSocketAddress(), conf);
+                        oldProxies.put(nextNode.getInetSocketAddress(), proxy);
+                      }
+
+                      return (LiveRMsResponse) proxy.getLiveRMList();
+                    } catch (IOException ex) {
+                      LOG.warn(ex, ex);
+                    } catch (YarnException ex) {
+                      LOG.warn(ex, ex);
+                    }
+                    return null;
+                  }
+                });
+        if (response == null) {
+          activeNodes.remove(nextNode);
+          anList = new SortedActiveRMList(activeNodes);
+          continue;
+        }
         anList = response.getLiveRMsList();
         return;
-      } catch (Exception e) {
-        activeNodes.remove(nextNode);
-        anList = new SortedActiveRMList(activeNodes);
-        continue;
+      } catch (IOException e) {
+        LOG.error(e, e);
       }
     }
     updateFromConfigFile();
@@ -121,22 +149,41 @@ public class GroupMembershipProxyService implements Closeable {
       conf.set(YarnConfiguration.RM_HA_ID, rmServiceIds[currentProxyIndex]);
       try {
         LOG.info("connecting to " + rmServiceIds[currentProxyIndex]);
-        final InetSocketAddress rmAddress =
-            rmProxy.getRMAddress(conf, protocol);
-        GroupMembership proxy = oldProxies.get(rmAddress);
-        if (proxy == null) {
-          proxy = RMProxy.getProxy(conf, protocol, rmAddress);
-          oldProxies.put(rmAddress, proxy);
+        final InetSocketAddress rmAddress = rmProxy.getRMAddress(conf, protocol);
+        UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+        if (ugi.getRealUser() != null) {
+          ugi = ugi.getRealUser();
         }
-
-        LiveRMsResponse response = proxy.getLiveRMList();
+        LiveRMsResponse response = ugi
+                .doAs(new PrivilegedAction<LiveRMsResponse>() {
+                  @Override
+                  public LiveRMsResponse run() {
+                    try {
+                      GroupMembership proxy = oldProxies.get(rmAddress);
+                      if (proxy == null) {
+                        proxy = RMProxy.getProxy(conf, protocol, rmAddress);
+                        oldProxies.put(rmAddress, proxy);
+                      }
+                      return (LiveRMsResponse) proxy.getLiveRMList();
+                    } catch (IOException ex) {
+                      LOG.warn(ex, ex);
+                    } catch (YarnException ex) {
+                      LOG.warn(ex, ex);
+                    }
+                    return null;
+                  }
+                });
+        if (response == null) {
+          LOG.info("Unable to create proxy to the ResourceManager "
+                  + rmServiceIds[currentProxyIndex]);
+          anList = null;
+          tries++;
+          continue;
+        }
         anList = response.getLiveRMsList();
         return;
-      } catch (Exception e) {
-        LOG.error("Unable to create proxy to the ResourceManager " +
-            rmServiceIds[currentProxyIndex]);
-        anList = null;
-        tries++;
+      } catch (IOException e) {
+        LOG.error(e, e);
       }
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/event/AsyncDispatcher.java
@@ -284,7 +284,7 @@ public class AsyncDispatcher extends AbstractService implements Dispatcher {
 
     void addHandler(EventHandler<Event> handler) {
       listofHandlers.add(handler);
-    }
+      }
 
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/RMContextInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/RMContextInfo.java
@@ -127,6 +127,10 @@ public class RMContextInfo {
     }
   }
 
+  public RMNodeToAdd getToAddActiveRMNode(NodeId nodeId){
+    return activeNodesToAdd.get(nodeId);
+  }
+  
   public void persistActiveNodeToRemove() throws StorageException {
     if (!activeNodesToRemove.isEmpty()) {
       ArrayList<RMContextActiveNodes> rmctxnodesToRemove =
@@ -177,6 +181,7 @@ public class RMContextInfo {
         toAddRMNodes.add(val.getRmNode());
         rmctxnodesToAdd.add(val.getHopCtxNode());
       }
+      //TODO change do add all the rmnode at the same place
       rmnodeDA.addAll(toAddRMNodes);
       resourceDA.addAll(toAddResources);
       nodeDA.addAll(nodesToAdd);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/RMNodeInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/RMNodeInfo.java
@@ -416,7 +416,7 @@ public void agregateFinishedApplicationToRemove(RMNodeInfoAgregate agregate){
   private void generatePendingEventId() {
     //lets start the pending event id from 1
     if(pendingId == -1){
-      this.pendingId = pendingEventId.getAndIncrement() + 1;
+      this.pendingId = pendingEventId.incrementAndGet();
     }
   }
 
@@ -430,15 +430,20 @@ public void agregateFinishedApplicationToRemove(RMNodeInfoAgregate agregate){
   }
 
   public void addPendingEventToAdd(String rmnodeId, int type, int status) {
-    PendingEvent pendingEvent = new PendingEvent(rmnodeId, type, status,
-            getPendingId());
+    PendingEvent pendingEvent;
+    if (this.persistedEventsToAdd.isEmpty()) {
+      pendingEvent = new PendingEvent(rmnodeId, type, status,
+              getPendingId());
+    } else {
+      pendingEvent = new PendingEvent(rmnodeId, type, status,
+              pendingEventId.incrementAndGet());
+    }
     this.persistedEventsToAdd.add(pendingEvent);
   }
 
-  public void addPendingEventToRemove(int id, String rmnodeId, int type,
-          int status) {
+  public void addPendingEventToRemove(PendingEvent pendingEvent) {
     this.persistedEventsToRemove
-            .add(new PendingEvent(rmnodeId, type, status, id));
+            .add(new PendingEvent(pendingEvent));
   }
 
   public void agregatePendingEventsToAdd(RMNodeInfoAgregate agregate) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/TransactionStateImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/TransactionStateImpl.java
@@ -16,6 +16,7 @@
 package io.hops.ha.common;
 
 import io.hops.StorageConnector;
+import io.hops.common.GlobalThreadPool;
 import io.hops.exception.StorageException;
 import io.hops.metadata.util.RMStorageFactory;
 import io.hops.metadata.util.RMUtilities;
@@ -51,6 +52,7 @@ import io.hops.metadata.yarn.entity.LaunchedContainers;
 import io.hops.metadata.yarn.entity.PendingEvent;
 import io.hops.metadata.yarn.entity.RMContainer;
 import io.hops.metadata.yarn.entity.RMNode;
+import io.hops.metadata.yarn.entity.RMNodeToAdd;
 import io.hops.metadata.yarn.entity.Resource;
 import io.hops.metadata.yarn.entity.rmstatestore.AllocateResponse;
 import io.hops.metadata.yarn.entity.rmstatestore.ApplicationAttemptState;
@@ -187,7 +189,7 @@ public class TransactionStateImpl extends TransactionState {
       RMUtilities.putTransactionStateInQueues(this, rmNodesToUpdate.keySet(), appIds);
       RMUtilities.logPutInCommitingQueue(this);
     }
-    manager.getExecutorService().execute(new RPCFinisher(this));
+    GlobalThreadPool.getExecutorService().execute(new RPCFinisher(this));
   }
 
   public FairSchedulerNodeInfo getFairschedulerNodeInfo() {
@@ -522,7 +524,7 @@ public class TransactionStateImpl extends TransactionState {
               toPersist.getProto().toByteArray(), allocatedContainers, 
       allocateResponse.getAllocateResponse().getResponseId(), completedContainersStatuses));
       if(toPersist.getProto().toByteArray().length>1000){
-        LOG.info("add allocateResponse of size " + toPersist.getProto().toByteArray().length + 
+        LOG.debug("add allocateResponse of size " + toPersist.getProto().toByteArray().length + 
                 " for " + id + " content: " + print(toPersist));
       }
       allocateResponsesToRemove.remove(id);
@@ -696,7 +698,14 @@ public class TransactionStateImpl extends TransactionState {
             rmnodeToAdd.getNodeManagerVersion(), -1,
             ((RMNodeImpl) rmnodeToAdd).getUpdatedContainerInfoId(),
             pendingEventId);
-    this.rmNodesToUpdate.put(rmnodeToAdd.getNodeID().toString(), hopRMNode);
+    
+    RMNodeToAdd hopRMNodeToAdd = getRMContextInfo().getToAddActiveRMNode(rmnodeToAdd.getNodeID());
+    if(hopRMNodeToAdd==null){
+      this.rmNodesToUpdate.put(rmnodeToAdd.getNodeID().toString(),
+              hopRMNode);
+    } else {
+      hopRMNodeToAdd.setRMNode(hopRMNode);
+    }
   }
 
   public Map<String, RMNode> getRMNodesToUpdate(){

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMStorageFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMStorageFactory.java
@@ -68,11 +68,11 @@ public class RMStorageFactory {
     return dStorageFactory.getConnector();
   }
 
-  public static void kickTheNdbEventStreamingAPI() throws
+  public static void kickTheNdbEventStreamingAPI(boolean isLeader) throws
           StorageInitializtionException {
     dNdbEventStreaming = DalDriver.loadHopsNdbEventStreamingLib(
             YarnAPIStorageFactory.NDB_EVENT_STREAMING_FOR_DISTRIBUTED_SERVICE);
-    dNdbEventStreaming.startHopsNdbEvetAPISession();
+    dNdbEventStreaming.startHopsNdbEvetAPISession(isLeader);
   }
   
   public static void setConfiguration(Configuration conf)

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMUtilities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMUtilities.java
@@ -166,8 +166,10 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.yarn.api.records.impl.pb.ContainerPBImpl;
 import org.apache.hadoop.yarn.proto.YarnProtos;
+import static org.apache.hadoop.yarn.server.resourcemanager.ResourceTrackerService.resolve;
 
 public class RMUtilities {
 
@@ -237,22 +239,13 @@ public class RMUtilities {
    * @throws IOException
    */
   public static List<ApplicationState> getApplicationStates()
-      throws IOException {
-    LightWeightRequestHandler getApplicationStateHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            ApplicationStateDataAccess DA =
-                (ApplicationStateDataAccess) RMStorageFactory
-                    .getDataAccess(ApplicationStateDataAccess.class);
-            List<ApplicationState> appStates = DA.getAll();
-            connector.commit();
-            return appStates;
-          }
-        };
-    return (List<ApplicationState>) getApplicationStateHandler.handle();
+          throws IOException {
+
+    ApplicationStateDataAccess DA
+            = (ApplicationStateDataAccess) RMStorageFactory
+            .getDataAccess(ApplicationStateDataAccess.class);
+    return DA.getAll();
+
   }
 
   /**
@@ -357,74 +350,51 @@ public class RMUtilities {
   }
 
   public static Map<RMStateStore.KeyType, MasterKey> getSecretMamagerKeys()
-      throws IOException {
-    LightWeightRequestHandler getNMTokenSecretMamagerCurrentKeyHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask()
-              throws StorageException, InvalidProtocolBufferException {
-            connector.beginTransaction();
-            connector.writeLock();
-            SecretMamagerKeysDataAccess DA =
-                (SecretMamagerKeysDataAccess) RMStorageFactory
-                    .getDataAccess(SecretMamagerKeysDataAccess.class);
-            List<SecretMamagerKey> hopKeys =
-                (List<SecretMamagerKey>) DA.getAll();
-            connector.commit();
-            Map<RMStateStore.KeyType, MasterKey> keys =
-                new EnumMap<RMStateStore.KeyType, MasterKey>(
+          throws IOException {
+
+    SecretMamagerKeysDataAccess DA
+            = (SecretMamagerKeysDataAccess) RMStorageFactory
+            .getDataAccess(SecretMamagerKeysDataAccess.class);
+    List<SecretMamagerKey> hopKeys = (List<SecretMamagerKey>) DA.getAll();
+    Map<RMStateStore.KeyType, MasterKey> keys
+            = new EnumMap<RMStateStore.KeyType, MasterKey>(
                     RMStateStore.KeyType.class);
-            MasterKey key;
-            if (hopKeys != null) {
-              for (SecretMamagerKey hopKey : hopKeys) {
-                key = new MasterKeyPBImpl(YarnServerCommonProtos.MasterKeyProto
-                    .parseFrom(hopKey.getKey()));
-                keys.put(RMStateStore.KeyType.valueOf(hopKey.getKeyType()),
-                    key);
-              }
-            }
-            return keys;
-          }
-        };
-    return (Map<RMStateStore.KeyType, MasterKey>) getNMTokenSecretMamagerCurrentKeyHandler
-        .handle();
+    MasterKey key;
+    if (hopKeys != null) {
+      for (SecretMamagerKey hopKey : hopKeys) {
+        key = new MasterKeyPBImpl(YarnServerCommonProtos.MasterKeyProto
+                .parseFrom(hopKey.getKey()));
+        keys.put(RMStateStore.KeyType.valueOf(hopKey.getKeyType()),
+                key);
+      }
+    }
+    return keys;
+
   }
   
-  public static Map<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse> getAllocateResponses(final RMContext rmContext)
-      throws IOException {
-    LightWeightRequestHandler allocateResponsesHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            AllocateResponseDataAccess da =
-                (AllocateResponseDataAccess) RMStorageFactory
-                    .getDataAccess(AllocateResponseDataAccess.class);
-            Map<String, AllocateResponse> hopAllocateResponses =
-                (Map<String, AllocateResponse>) da.getAll();
-            connector.commit();
-            Map<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse>
-                allocateResponses =
-                new HashMap<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse>();
-            if (hopAllocateResponses != null) {
-              for (AllocateResponse hopAllocateResponse : hopAllocateResponses.values()) {
-                org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse
-                    allocateResponse = new AllocateResponsePBImpl(
-                    YarnServiceProtos.AllocateResponseProto
+  public static Map<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse> getAllocateResponses(
+          final RMContext rmContext)
+          throws IOException {
+    AllocateResponseDataAccess da
+            = (AllocateResponseDataAccess) RMStorageFactory
+            .getDataAccess(AllocateResponseDataAccess.class);
+    Map<String, AllocateResponse> hopAllocateResponses
+            = (Map<String, AllocateResponse>) da.getAll();
+    Map<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse> allocateResponses
+            = new HashMap<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse>();
+    if (hopAllocateResponses != null) {
+      for (AllocateResponse hopAllocateResponse : hopAllocateResponses.values()) {
+        org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse allocateResponse
+                = new AllocateResponsePBImpl(
+                        YarnServiceProtos.AllocateResponseProto
                         .parseFrom(hopAllocateResponse.getAllocateResponse()));
-                allocateResponses.put(ConverterUtils.toApplicationAttemptId(
-                    hopAllocateResponse.getApplicationattemptid()),
-                    allocateResponse);
-              }
-            }
-            setAllocatedContainers(allocateResponses);
-            return allocateResponses;
-          }
-        };
-    return (Map<ApplicationAttemptId, org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse>) allocateResponsesHandler
-        .handle();
+        allocateResponses.put(ConverterUtils.toApplicationAttemptId(
+                hopAllocateResponse.getApplicationattemptid()),
+                allocateResponse);
+      }
+    }
+    setAllocatedContainers(allocateResponses);
+    return allocateResponses;
   }
 
   private static void setAllocatedContainers(
@@ -456,22 +426,10 @@ public class RMUtilities {
     
   private static Map<String, List<String>> getAllAllocatedContainers() throws
           IOException {
-    LightWeightRequestHandler getAllocatedContainers
-            = new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-              @Override
-              public Object performTask() throws IOException {
-                connector.beginTransaction();
-                connector.writeLock();
-                AllocatedContainersDataAccess da
-                = (AllocatedContainersDataAccess) RMStorageFactory.
-                getDataAccess(AllocatedContainersDataAccess.class);
-                Map<String, List<String>> allocatedContainersId = da.getAll();
-                connector.commit();
-                return allocatedContainersId;
-              }
-            };
-    return (Map<String, List<String>>) getAllocatedContainers.handle();
+    AllocatedContainersDataAccess da
+            = (AllocatedContainersDataAccess) RMStorageFactory.
+            getDataAccess(AllocatedContainersDataAccess.class);
+    return da.getAll();
   }
       
   /**
@@ -481,44 +439,37 @@ public class RMUtilities {
    * @throws IOException
    */
   public static List<RPC> getAppMasterRPCs() throws IOException {
-    LightWeightRequestHandler getAppMasterRPCHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            RPCDataAccess DA = (RPCDataAccess) RMStorageFactory
-                .getDataAccess(RPCDataAccess.class);
-            List<RPC> appMasterRPCs = DA.getAll();
-            connector.commit();
-            return appMasterRPCs;
-          }
-        };
-    return (List<RPC>) getAppMasterRPCHandler.handle();
+    RPCDataAccess DA = (RPCDataAccess) RMStorageFactory
+            .getDataAccess(RPCDataAccess.class);
+    return DA.getAll();
   }
 
-  public static List<AppSchedulingInfo> getAppSchedulingInfos()
-      throws IOException {
-    LightWeightRequestHandler handler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
+  public static List<PendingEvent> getAllPendingEvents() throws IOException {
 
-          @Override
-          public Object performTask() throws IOException {
-            //        connector.readCommitted();
-            connector.beginTransaction();
-            connector.writeLock();
-            AppSchedulingInfoDataAccess dA =
-                (AppSchedulingInfoDataAccess) RMStorageFactory
-                    .getDataAccess(AppSchedulingInfoDataAccess.class);
-            List<AppSchedulingInfo> result = dA.findAll();
-            connector.commit();
-            return result;
-          }
-        };
-    return (List<AppSchedulingInfo>) handler.handle();
+    PendingEventDataAccess DA = (PendingEventDataAccess) RMStorageFactory.
+            getDataAccess(PendingEventDataAccess.class);
+    return DA.getAll();
+
+  }
+  
+  public static List<AppSchedulingInfo> getAppSchedulingInfos()
+          throws IOException {
+    AppSchedulingInfoDataAccess dA
+            = (AppSchedulingInfoDataAccess) RMStorageFactory
+            .getDataAccess(AppSchedulingInfoDataAccess.class);
+    return dA.findAll();
   }
   
   public static Map<String, SchedulerApplication> getSchedulerApplications()
+      throws IOException {
+            SchedulerApplicationDataAccess DA =
+                (SchedulerApplicationDataAccess) RMStorageFactory
+                    .getDataAccess(SchedulerApplicationDataAccess.class);
+            return DA.getAll();
+          
+  }
+
+    public static Map<String, SchedulerApplication> getSchedulerApplicationsFullTransaction()
       throws IOException {
     LightWeightRequestHandler getSchedulerApplicationHandler =
         new LightWeightRequestHandler(YARNOperationType.TEST) {
@@ -538,8 +489,18 @@ public class RMUtilities {
     return (Map<String, SchedulerApplication>) getSchedulerApplicationHandler
         .handle();
   }
-
+    
   public static Map<String, FiCaSchedulerNode> getAllFiCaSchedulerNodes()
+          throws IOException {
+
+    FiCaSchedulerNodeDataAccess DA
+            = (FiCaSchedulerNodeDataAccess) RMStorageFactory
+            .getDataAccess(FiCaSchedulerNodeDataAccess.class);
+    return DA.getAll();
+
+  }
+
+    public static Map<String, FiCaSchedulerNode> getAllFiCaSchedulerNodesFullTransaction()
       throws IOException {
     LightWeightRequestHandler getFiCaSchedulerNodesHandler =
         new LightWeightRequestHandler(YARNOperationType.TEST) {
@@ -557,27 +518,14 @@ public class RMUtilities {
         };
     return (Map<String, FiCaSchedulerNode>) getFiCaSchedulerNodesHandler.handle();
   }
-
-  
+    
   public static Map<String, List<LaunchedContainers>> getAllLaunchedContainers()
-      throws IOException {
-    LightWeightRequestHandler getLaunchedContainersHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            LaunchedContainersDataAccess DA =
-                (LaunchedContainersDataAccess) RMStorageFactory
-                    .getDataAccess(LaunchedContainersDataAccess.class);
-            Map<String, List<LaunchedContainers>> hopLaunchedContainers =
-                DA.getAll();
-            connector.commit();
-            return hopLaunchedContainers;
-          }
-        };
-    return (Map<String, List<LaunchedContainers>>) getLaunchedContainersHandler.
-        handle();
+          throws IOException {
+
+    LaunchedContainersDataAccess DA
+            = (LaunchedContainersDataAccess) RMStorageFactory
+            .getDataAccess(LaunchedContainersDataAccess.class);
+    return DA.getAll();
   }
 
   //For testing TODO move to test
@@ -653,6 +601,14 @@ public class RMUtilities {
   
 
   public static Map<String, List<ResourceRequest>> getAllResourceRequests()
+          throws IOException {
+
+    ResourceRequestDataAccess DA = (ResourceRequestDataAccess) RMStorageFactory
+            .getDataAccess(ResourceRequestDataAccess.class);
+    return DA.getAll();
+  }
+  
+public static Map<String, List<ResourceRequest>> getAllResourceRequestsFullTransaction()
       throws IOException {
     LightWeightRequestHandler getResourceRequestsHandler =
         new LightWeightRequestHandler(YARNOperationType.TEST) {
@@ -672,27 +628,13 @@ public class RMUtilities {
     return (Map<String, List<ResourceRequest>>) getResourceRequestsHandler
         .handle();
   }
-  
 
   public static Map<String, List<AppSchedulingInfoBlacklist>> getAllBlackLists()
-      throws IOException {
-    LightWeightRequestHandler getBlackListHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            AppSchedulingInfoBlacklistDataAccess DA =
-                (AppSchedulingInfoBlacklistDataAccess) RMStorageFactory
-                    .getDataAccess(AppSchedulingInfoBlacklistDataAccess.class);
-            Map<String, List<AppSchedulingInfoBlacklist>> hopBlackList =
-                DA.getAll();
-            connector.commit();
-            return hopBlackList;
-          }
-        };
-    return (Map<String, List<AppSchedulingInfoBlacklist>>) getBlackListHandler
-        .handle();
+          throws IOException {
+    AppSchedulingInfoBlacklistDataAccess DA
+            = (AppSchedulingInfoBlacklistDataAccess) RMStorageFactory
+            .getDataAccess(AppSchedulingInfoBlacklistDataAccess.class);
+    return DA.getAll();
   }
 
   /**
@@ -703,25 +645,17 @@ public class RMUtilities {
    * @throws IOException
    */
   public static Integer getRMSequentialNumber(final int id) throws IOException {
-    LightWeightRequestHandler getSequentialNumberHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            SequenceNumberDataAccess DA =
-                (SequenceNumberDataAccess) RMStorageFactory
-                    .getDataAccess(SequenceNumberDataAccess.class);
-            SequenceNumber hseqNumber = (SequenceNumber) DA.findById(id);
-            Integer seqNumber = null;
-            if (hseqNumber != null) {
-              seqNumber = hseqNumber.getSequencenumber();
-            }
-            connector.commit();
-            return seqNumber;
-          }
-        };
-    return (Integer) getSequentialNumberHandler.handle();
+
+    SequenceNumberDataAccess DA = (SequenceNumberDataAccess) RMStorageFactory
+            .getDataAccess(SequenceNumberDataAccess.class);
+    SequenceNumber hseqNumber = (SequenceNumber) DA.findById(id);
+    Integer seqNumber = null;
+    if (hseqNumber != null) {
+      seqNumber = hseqNumber.getSequencenumber();
+    }
+
+    return seqNumber;
+
   }
 
   /**
@@ -731,21 +665,11 @@ public class RMUtilities {
    * @throws IOException
    */
   public static List<DelegationToken> getDelegationTokens() throws IOException {
-    LightWeightRequestHandler getDelegationTokenHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            DelegationTokenDataAccess DA =
-                (DelegationTokenDataAccess) RMStorageFactory
-                    .getDataAccess(DelegationTokenDataAccess.class);
-            List<DelegationToken> delTokens = DA.getAll();
-            connector.commit();
-            return delTokens;
-          }
-        };
-    return (List<DelegationToken>) getDelegationTokenHandler.handle();
+
+    DelegationTokenDataAccess DA = (DelegationTokenDataAccess) RMStorageFactory
+            .getDataAccess(DelegationTokenDataAccess.class);
+    return DA.getAll();
+
   }
 
   /**
@@ -755,21 +679,11 @@ public class RMUtilities {
    * @throws IOException
    */
   public static List<DelegationKey> getDelegationKeys() throws IOException {
-    LightWeightRequestHandler getDelegationKeyHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            DelegationKeyDataAccess DA =
-                (DelegationKeyDataAccess) RMStorageFactory
-                    .getDataAccess(DelegationKeyDataAccess.class);
-            List<DelegationKey> delKeys = DA.getAll();
-            connector.commit();
-            return delKeys;
-          }
-        };
-    return (List<DelegationKey>) getDelegationKeyHandler.handle();
+
+    DelegationKeyDataAccess DA = (DelegationKeyDataAccess) RMStorageFactory
+            .getDataAccess(DelegationKeyDataAccess.class);
+    return DA.getAll();
+
   }
 
   /**
@@ -1008,6 +922,140 @@ public class RMUtilities {
     return (RMNodeComps) getRMNodeBatchHandler.handle();
   }
   
+  public static org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode processHopRMNodeCompsForScheduler(
+          RMNodeComps hopRMNodeFull,
+          RMContext rmContext) throws
+          InvalidProtocolBufferException {
+    NodeId nodeId;
+    org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode rmNode = null;
+    if (hopRMNodeFull != null) {
+      nodeId = ConverterUtils.toNodeId(hopRMNodeFull.getRMNodeId());
+
+      rmNode = rmContext.getActiveRMNodes().get(nodeId);
+      // so first time we are receiving , this will happen when node registers
+      if (rmNode == null) {
+        org.apache.hadoop.net.Node node = null;
+        if (hopRMNodeFull.getHopRMNode().getNodeId() != null) {
+          node = new NodeBase(hopRMNodeFull.getHopNode().getName(),
+                  hopRMNodeFull.
+                  getHopNode().getLocation());
+          if (hopRMNodeFull.getHopNode().getParent() != null) {
+            node.setParent(new NodeBase(hopRMNodeFull.getHopNode().getParent()));
+          }
+          node.setLevel(hopRMNodeFull.getHopNode().getLevel());
+        }
+        //Retrieve nextHeartbeat
+        boolean nextHeartbeat = true;
+        //Create Resource
+        ResourceOption resourceOption = null;
+        if (hopRMNodeFull.getHopResource() != null) {
+          resourceOption = ResourceOption
+                  .newInstance(org.apache.hadoop.yarn.api.records.Resource.
+                          newInstance(hopRMNodeFull.getHopResource().
+                                  getMemory(),
+                                  hopRMNodeFull.getHopResource().
+                                  getVirtualCores()),
+                          hopRMNodeFull.getHopRMNode().getOvercommittimeout());
+        }
+        //Create RMNode from HopRMNode
+        rmNode = new RMNodeImpl(nodeId, rmContext,
+                hopRMNodeFull.getHopRMNode().getHostName(),
+                hopRMNodeFull.getHopRMNode().getCommandPort(),
+                hopRMNodeFull.getHopRMNode().getHttpPort(),
+                resolve(hopRMNodeFull.getHopRMNode().getHostName()),
+                resourceOption,
+                hopRMNodeFull.getHopRMNode().getNodemanagerVersion(),
+                hopRMNodeFull.getHopRMNode().getHealthReport(),
+                hopRMNodeFull.getHopRMNode().getLastHealthReportTime(),
+                nextHeartbeat);
+
+        //This is  to force java to put the host in cash 
+        //for quick loop-up in scheduler container allocation  
+        NetUtils.createSocketAddrForHost(nodeId.getHost(), nodeId.
+                getPort());
+      }
+      // now we update the rmnode
+      if (hopRMNodeFull.getHopRMNode() != null) {
+        ((RMNodeImpl) rmNode).setState(hopRMNodeFull.getHopRMNode().
+                getCurrentState());
+      }
+      if (hopRMNodeFull.getHopUpdatedContainerInfo() != null) {
+        List<UpdatedContainerInfo> hopUpdatedContainerInfoList
+                = hopRMNodeFull.getHopUpdatedContainerInfo();
+        if (hopUpdatedContainerInfoList != null && !hopUpdatedContainerInfoList.
+                isEmpty()) {
+          ConcurrentLinkedQueue<org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo> updatedContainerInfoQueue
+                  = new ConcurrentLinkedQueue<org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo>();
+          Map<Integer, org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo> ucis
+                  = new HashMap<Integer, org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo>();
+          LOG.debug(hopRMNodeFull.getRMNodeId() + " geting ucis "
+                  + hopUpdatedContainerInfoList.size() + " pending event "
+                  + hopRMNodeFull.getPendingEvent().getId().getEventId());
+          for (UpdatedContainerInfo hopUCI : hopUpdatedContainerInfoList) {
+            if (!ucis.containsKey(hopUCI.getUpdatedContainerInfoId())) {
+              ucis.put(hopUCI.getUpdatedContainerInfoId(),
+                      new org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo(
+                              new ArrayList<org.apache.hadoop.yarn.api.records.ContainerStatus>(),
+                              new ArrayList<org.apache.hadoop.yarn.api.records.ContainerStatus>(),
+                              hopUCI.getUpdatedContainerInfoId()));
+            }
+
+            org.apache.hadoop.yarn.api.records.ContainerId cid = ConverterUtils.
+                    toContainerId(hopUCI.
+                            getContainerId());
+            ContainerStatus hopContainerStatus = hopRMNodeFull.
+                    getHopContainersStatusMap().get(hopUCI.getContainerId());
+            org.apache.hadoop.yarn.api.records.ContainerStatus conStatus
+                    = org.apache.hadoop.yarn.api.records.ContainerStatus.
+                    newInstance(cid,
+                            ContainerState.
+                            valueOf(hopContainerStatus.getState()),
+                            hopContainerStatus.getDiagnostics(),
+                            hopContainerStatus.getExitstatus());
+            //Check ContainerStatus state to add it to appropriate list
+            if (conStatus != null) {
+              LOG.debug("add uci for container " + conStatus.getContainerId()
+                      + " status " + conStatus.getState());
+              if (conStatus.getState().equals(ContainerState.RUNNING)) {
+                ucis.get(hopUCI.getUpdatedContainerInfoId()).
+                        getNewlyLaunchedContainers().add(conStatus);
+              } else if (conStatus.getState().equals(ContainerState.COMPLETE)) {
+                ucis.get(hopUCI.getUpdatedContainerInfoId()).
+                        getCompletedContainers().add(conStatus);
+              }
+            }
+          }
+          int maxUciId = 0;
+          for (org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo uci
+                  : ucis.values()) {
+            if (uci.getCompletedContainers().size() > 0) {
+              LOG.debug(rmNode.getNodeID()
+                      + " add completed containers to uci queue uci " + uci.
+                      getUpdatedContainerInfoId());
+            }
+            updatedContainerInfoQueue.add(uci);
+            if (uci.getUpdatedContainerInfoId() > maxUciId) {
+              maxUciId = uci.getUpdatedContainerInfoId();
+            }
+          }
+
+          ((RMNodeImpl) rmNode).setUpdatedContainerInfoId(maxUciId);
+          ((RMNodeImpl) rmNode).setUpdatedContainerInfo(
+                  updatedContainerInfoQueue);
+        } else {
+          LOG.debug(hopRMNodeFull.getRMNodeId()
+                  + " hopUpdatedContainerInfoList = null || hopUpdatedContainerInfoList.isEmpty() "
+                  + hopRMNodeFull.getPendingEvent().getId().getEventId());
+        }
+      } else {
+        LOG.debug(hopRMNodeFull.getRMNodeId()
+                + " hopRMNodeFull.getHopUpdatedContainerInfo()=null "
+                + hopRMNodeFull.getPendingEvent().getId().getEventId());
+      }
+    }
+    return rmNode;
+  }
+    
   public static org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode getRMNode(
       final String id, final RMContext context, final Configuration conf)
       throws IOException {
@@ -1060,9 +1108,7 @@ public class RMUtilities {
                   hopRMNode.getCommandPort(), hopRMNode.getHttpPort(), node,
                   resourceOption, hopRMNode.getNodemanagerVersion(),
                   hopRMNode.getHealthReport(),
-                  hopRMNode.getLastHealthReportTime(), nextHeartbeat,
-                  conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                      YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+                  hopRMNode.getLastHealthReportTime(), nextHeartbeat);
 
               ((RMNodeImpl) rmNode).setState(hopRMNode.getCurrentState());
               // *** Recover maps/lists of RMNode ***
@@ -1231,21 +1277,10 @@ public class RMUtilities {
    * @throws IOException
    */
   public static Map<String, Boolean> getAllNextHeartbeats() throws IOException {
-    LightWeightRequestHandler getAllNextHeartbeatsHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            NextHeartbeatDataAccess nextHBDA =
-                (NextHeartbeatDataAccess) RMStorageFactory.
-                    getDataAccess(NextHeartbeatDataAccess.class);
-            Map<String, Boolean> allNextHeartbeats = nextHBDA.getAll();
-            connector.commit();
-            return allNextHeartbeats;
-          }
-        };
-    return (Map<String, Boolean>) getAllNextHeartbeatsHandler.handle();
+    NextHeartbeatDataAccess nextHBDA
+            = (NextHeartbeatDataAccess) RMStorageFactory.
+            getDataAccess(NextHeartbeatDataAccess.class);
+    return nextHBDA.getAll();
   }
   
   /**
@@ -1330,11 +1365,12 @@ public class RMUtilities {
               pendingEvents = DA.getAll(status);
               if (pendingEvents != null && !pendingEvents.isEmpty()) {
                 for (PendingEvent hop : pendingEvents) {
-                  if (!pendingEventsByRMNode.containsKey(hop.getRmnodeId())) {
-                    pendingEventsByRMNode.put(hop.getRmnodeId(),
-                        new ConcurrentSkipListSet<PendingEvent>());
+                  if (!pendingEventsByRMNode.
+                          containsKey(hop.getId().getNodeId())) {
+                    pendingEventsByRMNode.put(hop.getId().getNodeId(),
+                            new ConcurrentSkipListSet<PendingEvent>());
                   }
-                  pendingEventsByRMNode.get(hop.getRmnodeId()).add(hop);
+                  pendingEventsByRMNode.get(hop.getId().getNodeId()).add(hop);
                 }
               }
             }
@@ -1381,14 +1417,17 @@ public class RMUtilities {
                     new ArrayList<PendingEvent>();
 
                 for (PendingEvent hop : pendingEvents) {
-                  if (!pendingEventsByRMNode.containsKey(hop.getRmnodeId())) {
-                    pendingEventsByRMNode.put(hop.getRmnodeId(),
-                        new ConcurrentSkipListSet<PendingEvent>());
+                  if (!pendingEventsByRMNode.
+                          containsKey(hop.getId().getNodeId())) {
+                    pendingEventsByRMNode.put(hop.getId().getNodeId(),
+                            new ConcurrentSkipListSet<PendingEvent>());
                   }
-                  pendingEventsByRMNode.get(hop.getRmnodeId()).add(hop);
+                  pendingEventsByRMNode.get(hop.getId().getNodeId()).add(hop);
                   PendingEvent pending =
-                      new PendingEvent(hop.getRmnodeId(), hop.getType(),
-                          TablesDef.PendingEventTableDef.PENDING, hop.getId());
+                    new PendingEvent(hop.getId().
+                          getNodeId(), hop.getType(),
+                          TablesDef.PendingEventTableDef.PENDING, hop.getId().
+                          getEventId());
                   pendingEventsModified.add(pending);
                 }
                 DA.addAll(pendingEventsModified);
@@ -1535,63 +1574,27 @@ public class RMUtilities {
    * @throws IOException
    */
   public static Map<String, List<ApplicationAttemptState>> getAllApplicationAttemptStates()
-      throws IOException {
-    LightWeightRequestHandler getApplicationAttemptIdsByApplicationIdHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            ApplicationAttemptStateDataAccess DA =
-                (ApplicationAttemptStateDataAccess) RMStorageFactory
-                    .getDataAccess(ApplicationAttemptStateDataAccess.class);
-            Map<String, List<ApplicationAttemptState>> attempts = DA.getAll();
-            connector.commit();
-            return attempts;
-          }
-        };
-    return (Map<String, List<ApplicationAttemptState>>) getApplicationAttemptIdsByApplicationIdHandler
-        .handle();
+          throws IOException {
+    ApplicationAttemptStateDataAccess DA
+            = (ApplicationAttemptStateDataAccess) RMStorageFactory
+            .getDataAccess(ApplicationAttemptStateDataAccess.class);
+    return DA.getAll();
   }
 
-    public static Map<String, List<RanNode>> getAllRanNodes()
-      throws IOException {
-    LightWeightRequestHandler getRanNodeHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            RanNodeDataAccess DA =
-                (RanNodeDataAccess) RMStorageFactory
-                    .getDataAccess(RanNodeDataAccess.class);
-            Map<String, List<RanNode>> attempts = DA.getAll();
-            connector.commit();
-            return attempts;
-          }
-        };
-    return (Map<String, List<RanNode>>) getRanNodeHandler
-        .handle();
+   public static Map<String, List<RanNode>> getAllRanNodes()
+          throws IOException {
+    RanNodeDataAccess DA = (RanNodeDataAccess) RMStorageFactory
+            .getDataAccess(RanNodeDataAccess.class);
+    return DA.getAll();
   }
     
-      public static Map<String, List<UpdatedNode>> getAllUpdatedNodes()
-      throws IOException {
-    LightWeightRequestHandler getUpdatedNodeHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            UpdatedNodeDataAccess DA =
-                (UpdatedNodeDataAccess) RMStorageFactory
-                    .getDataAccess(UpdatedNodeDataAccess.class);
-            Map<String, List<UpdatedNode>> attempts = DA.getAll();
-            connector.commit();
-            return attempts;
-          }
-        };
-    return (Map<String, List<UpdatedNode>>) getUpdatedNodeHandler
-        .handle();
+  public static Map<String, List<UpdatedNode>> getAllUpdatedNodes()
+          throws IOException {
+
+    UpdatedNodeDataAccess DA = (UpdatedNodeDataAccess) RMStorageFactory
+            .getDataAccess(UpdatedNodeDataAccess.class);
+    return DA.getAll();
+
   }
       
   /**
@@ -1734,86 +1737,33 @@ public class RMUtilities {
 
   
   public static List<RMContextActiveNodes> getAllRMContextActiveNodes()
-      throws IOException {
-    LightWeightRequestHandler getAllRMContextActiveNodesHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            RMContextActiveNodesDataAccess rmctxnodesDA =
-                (RMContextActiveNodesDataAccess) RMStorageFactory.
-                    getDataAccess(RMContextActiveNodesDataAccess.class);
-            List<RMContextActiveNodes> hopRMContextNodes = rmctxnodesDA.
-                findAll();
-            connector.commit();
-            return hopRMContextNodes;
-          }
-        };
-    return (List<RMContextActiveNodes>) getAllRMContextActiveNodesHandler.
-        handle();
+          throws IOException {
+    RMContextActiveNodesDataAccess rmctxnodesDA
+            = (RMContextActiveNodesDataAccess) RMStorageFactory.
+            getDataAccess(RMContextActiveNodesDataAccess.class);
+    return rmctxnodesDA.
+            findAll();
   }
   
   public static Map<String, RMNode> getAllRMNodes() throws IOException {
-    LightWeightRequestHandler getAllRMNodesHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            RMNodeDataAccess rmDA = (RMNodeDataAccess) RMStorageFactory.
-                getDataAccess(RMNodeDataAccess.class);
-            Map<String, RMNode> rmNodes = rmDA.
-                getAll();
-            connector.commit();
-            return rmNodes;
-          }
-        };
-    return (Map<String, RMNode>) getAllRMNodesHandler.handle();
+    RMNodeDataAccess rmDA = (RMNodeDataAccess) RMStorageFactory.
+            getDataAccess(RMNodeDataAccess.class);
+    return rmDA.getAll();
   }
   
   public static Map<String, Node> getAllNodes() throws IOException {
-    LightWeightRequestHandler getAllNodesHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            NodeDataAccess nodeDA = (NodeDataAccess) RMStorageFactory
-                .getDataAccess(NodeDataAccess.class);
-            Map<String, Node> rmNodes = nodeDA.
-                getAll();
-            connector.commit();
-            return rmNodes;
-          }
-        };
-    return (Map<String, Node>) getAllNodesHandler.handle();
+    NodeDataAccess nodeDA = (NodeDataAccess) RMStorageFactory
+            .getDataAccess(NodeDataAccess.class);
+    return nodeDA.getAll();
   }
 
   
   public static List<RMContextInactiveNodes> getAllRMContextInactiveNodes()
-      throws IOException {
-    LightWeightRequestHandler getAllRMContextInactiveNodesHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            RMContextInactiveNodesDataAccess rmctxInactiveNodesDA =
-                (RMContextInactiveNodesDataAccess) RMStorageFactory.
-                    getDataAccess(RMContextInactiveNodesDataAccess.class);
-            List<RMContextInactiveNodes> hopRMContextInactiveNodes =
-                rmctxInactiveNodesDA.findAll();
-            connector.commit();
-            return hopRMContextInactiveNodes;
-          }
-        };
-    return (List<RMContextInactiveNodes>) getAllRMContextInactiveNodesHandler.
-        handle();
+          throws IOException {
+    RMContextInactiveNodesDataAccess rmctxInactiveNodesDA
+            = (RMContextInactiveNodesDataAccess) RMStorageFactory.
+            getDataAccess(RMContextInactiveNodesDataAccess.class);
+    return rmctxInactiveNodesDA.findAll();
   }
 
   
@@ -1893,10 +1843,7 @@ public class RMUtilities {
                         hopRMNode.getOvercommittimeout()),
                         hopRMNode.getNodemanagerVersion(),
                         hopRMNode.getHealthReport(),
-                        hopRMNode.getLastHealthReportTime(), nextHeartbeat,
-                        conf.getBoolean(
-                            YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                            YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+                        hopRMNode.getLastHealthReportTime(), nextHeartbeat);
                 ((RMNodeImpl) rmNode).setState(hopRMNode.getCurrentState());
                 alreadyRecoveredRMContextInactiveNodes
                     .put(rmNode.getNodeID().getHost(), rmNode);
@@ -1929,91 +1876,38 @@ public class RMUtilities {
   }
 
   public static Map<String, Map<Integer, List<UpdatedContainerInfo>>> getAllUpdatedContainerInfos()
-      throws IOException {
-    LightWeightRequestHandler getAllUpdatedContainerInfosHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            UpdatedContainerInfoDataAccess uciDA =
-                (UpdatedContainerInfoDataAccess) RMStorageFactory.
-                    getDataAccess(UpdatedContainerInfoDataAccess.class);
-            Map<String, Map<Integer, List<UpdatedContainerInfo>>>
-                allUpdatedContainerInfos = uciDA.getAll();
-            connector.commit();
-            return allUpdatedContainerInfos;
-          }
-        };
-    return (Map<String, Map<Integer, List<UpdatedContainerInfo>>>) getAllUpdatedContainerInfosHandler
-        .
-            handle();
+          throws IOException {
+    UpdatedContainerInfoDataAccess uciDA
+            = (UpdatedContainerInfoDataAccess) RMStorageFactory.
+            getDataAccess(UpdatedContainerInfoDataAccess.class);
+    return uciDA.getAll();
   }
   
   public static Map<String, ContainerStatus> getAllContainerStatus()
-      throws IOException {
-    LightWeightRequestHandler getAllContainerStatusHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            ContainerStatusDataAccess csDA =
-                (ContainerStatusDataAccess) YarnAPIStorageFactory.
-                    getDataAccess(ContainerStatusDataAccess.class);
-            Map<String, ContainerStatus> allContainerStatus = csDA.getAll();
-            connector.commit();
-            return allContainerStatus;
-          }
-        };
-    return (Map<String, ContainerStatus>) getAllContainerStatusHandler.
-        handle();
+          throws IOException {
+    ContainerStatusDataAccess csDA
+            = (ContainerStatusDataAccess) YarnAPIStorageFactory.
+            getDataAccess(ContainerStatusDataAccess.class);
+    return csDA.getAll();
   }
   
 
   public static Map<String, NodeHBResponse> getAllNodeHeartBeatResponse()
-      throws IOException {
-    LightWeightRequestHandler getNodeHeartBeatResponseHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
+          throws IOException {
 
-            NodeHBResponseDataAccess DA =
-                (NodeHBResponseDataAccess) RMStorageFactory
-                    .getDataAccess(NodeHBResponseDataAccess.class);
-            Map<String, NodeHBResponse> hop = DA.getAll();
-            connector.commit();
-            return hop;
-          }
-        };
-    
-    return (Map<String, NodeHBResponse>) getNodeHeartBeatResponseHandler
-        .handle();
+    NodeHBResponseDataAccess DA = (NodeHBResponseDataAccess) RMStorageFactory
+            .getDataAccess(NodeHBResponseDataAccess.class);
+    return DA.getAll();
+
   }
 
 
   public static Map<String, Set<ContainerId>> getAllContainersToClean()
-      throws IOException {
-    LightWeightRequestHandler getContainersToCleanHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            ContainerIdToCleanDataAccess tocleanDA =
-                (ContainerIdToCleanDataAccess) YarnAPIStorageFactory.
-                    getDataAccess(ContainerIdToCleanDataAccess.class);
-            Map<String, Set<ContainerId>> hopContainerIdToClean =
-                tocleanDA.getAll();
-            connector.commit();
-            return hopContainerIdToClean;
-          }
-        };
-    return (Map<String, Set<ContainerId>>) getContainersToCleanHandler.handle();
+          throws IOException {
+    ContainerIdToCleanDataAccess tocleanDA
+            = (ContainerIdToCleanDataAccess) YarnAPIStorageFactory.
+            getDataAccess(ContainerIdToCleanDataAccess.class);
+    return tocleanDA.getAll();
   }
 
   /**
@@ -2079,53 +1973,30 @@ public class RMUtilities {
   
   
   public static Map<String, List<FinishedApplications>> getAllFinishedApplications()
-      throws IOException {
-    LightWeightRequestHandler getFinishedApplicationsHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.writeLock();
-            FinishedApplicationsDataAccess finishedAppsDA =
-                (FinishedApplicationsDataAccess) RMStorageFactory.
-                    getDataAccess(FinishedApplicationsDataAccess.class);
-            Map<String, List<FinishedApplications>> hopFinishedApps =
-                finishedAppsDA.getAll();
-
-            connector.commit();
-            return hopFinishedApps;
-          }
-        };
-    return (Map<String, List<FinishedApplications>>) 
-            getFinishedApplicationsHandler.handle();
+          throws IOException {
+    FinishedApplicationsDataAccess finishedAppsDA
+            = (FinishedApplicationsDataAccess) RMStorageFactory.
+            getDataAccess(FinishedApplicationsDataAccess.class);
+    return finishedAppsDA.getAll();
   }
   
   public static Map<String, List<JustLaunchedContainers>> getAllJustLaunchedContainers()
-      throws IOException {
-    LightWeightRequestHandler getAllJustLaunchedContainersHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            JustLaunchedContainersDataAccess jlcDA =
-                (JustLaunchedContainersDataAccess) YarnAPIStorageFactory.
-                    getDataAccess(JustLaunchedContainersDataAccess.class);
-            Map<String, List<JustLaunchedContainers>> justLaunchedContainers =
-                jlcDA.getAll();
-            connector.commit();
-            return justLaunchedContainers;
-          }
-        };
-
-    return (Map<String, List<JustLaunchedContainers>>) getAllJustLaunchedContainersHandler
-        .
-            handle();
+          throws IOException {
+    JustLaunchedContainersDataAccess jlcDA
+            = (JustLaunchedContainersDataAccess) YarnAPIStorageFactory.
+            getDataAccess(JustLaunchedContainersDataAccess.class);
+    return jlcDA.getAll();
   }
   
 
   public static Map<String, RMContainer> getAllRMContainers()
+          throws IOException {
+    RMContainerDataAccess DA = (RMContainerDataAccess) RMStorageFactory
+            .getDataAccess(RMContainerDataAccess.class);
+    return DA.getAll();
+  }
+  
+  public static Map<String, RMContainer> getAllRMContainersFulTransaction()
       throws IOException {
 
     LightWeightRequestHandler getRMContainerHandler =
@@ -2145,38 +2016,17 @@ public class RMUtilities {
     return (Map<String, RMContainer>) getRMContainerHandler.handle();
   }
   
-
   public static Map<String, Container> getAllContainers() throws IOException {
-    LightWeightRequestHandler getContainerHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws IOException {
-            connector.beginTransaction();
-            connector.writeLock();
-            ContainerDataAccess DA = (ContainerDataAccess) RMStorageFactory.
-                getDataAccess(ContainerDataAccess.class);
-            Map<String, Container> found = DA.getAll();
-            connector.commit();
-            return found;
-          }
-        };
-    return (Map<String, Container>) getContainerHandler.handle();
+    ContainerDataAccess DA = (ContainerDataAccess) RMStorageFactory.
+            getDataAccess(ContainerDataAccess.class);
+    return DA.getAll();
   }
   
   
   public static List<QueueMetrics> getAllQueueMetrics() throws IOException {
-    LightWeightRequestHandler handler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws IOException {
-            connector.readCommitted();
-            QueueMetricsDataAccess qDA =
-                (QueueMetricsDataAccess) RMStorageFactory
-                    .getDataAccess(QueueMetricsDataAccess.class);
-            return qDA.findAll();
-          }
-        };
-    return (List<QueueMetrics>) handler.handle();
+    QueueMetricsDataAccess qDA = (QueueMetricsDataAccess) RMStorageFactory
+            .getDataAccess(QueueMetricsDataAccess.class);
+    return qDA.findAll();
   }
 
   static Map<String, Queue<TransactionState>> transactionStateForRMNode = 
@@ -2408,17 +2258,25 @@ public class RMUtilities {
                 rpcToRemove.add(hop);
               }
              DA.removeAll(rpcToRemove);
+             connector.flush();
 //            //TODO put all of this in ts.persist
-            ts.persistCSQueueInfo(csQDA, csLQDA);
-            ts.persistRMNodeToUpdate(rmnodeDA);
-            ts.persistRmcontextInfo(rmnodeDA, resourceDA, nodeDA,
+             ts.persistRmcontextInfo(rmnodeDA, resourceDA, nodeDA,
                 rmctxInactiveNodesDA);
+             connector.flush();
+            ts.persistCSQueueInfo(csQDA, csLQDA);
+            connector.flush();
+            ts.persistRMNodeToUpdate(rmnodeDA);
+            connector.flush();
             ts.persistRMNodeInfo(hbDA, cidToCleanDA, justLaunchedContainersDA,
                 updatedContainerInfoDA, faDA, csDA,persistedEventDA, connector);
+            connector.flush();
             ts.persist();
+            connector.flush();
             ts.persistFicaSchedulerNodeInfo(resourceDA, ficaNodeDA,
                 rmcontainerDA, launchedContainersDA);
+            connector.flush();
             ts.persistFairSchedulerNodeInfo(FSSNodeDA);
+            connector.flush();
             ts.persistSchedulerApplicationInfo(QMDA, connector);
             connector.commit();
             return null;
@@ -2468,25 +2326,10 @@ public class RMUtilities {
   }
 
   public static Map<String, Map<Integer, Map<Integer, Resource>>> getAllNodesResources()
-      throws IOException {
-    LightWeightRequestHandler getResourceHandler =
-        new LightWeightRequestHandler(YARNOperationType.TEST) {
-          @Override
-          public Object performTask() throws StorageException {
-            connector.beginTransaction();
-            connector.readCommitted();
-            ResourceDataAccess DA = (ResourceDataAccess) YarnAPIStorageFactory
-                .getDataAccess(ResourceDataAccess.class);
-            Map<String, Map<Integer, Map<Integer, Resource>>> res = DA.
-                getAll();
-            connector.commit();
-            return res;
-          }
-        };
-
-    return (Map<String, Map<Integer, Map<Integer, Resource>>>) getResourceHandler
-        .
-            handle();
+          throws IOException {
+    ResourceDataAccess DA = (ResourceDataAccess) YarnAPIStorageFactory
+            .getDataAccess(ResourceDataAccess.class);
+    return DA.getAll();
   }
   
   public static Map<String, Load> getAllLoads() throws IOException {
@@ -2541,105 +2384,56 @@ public class RMUtilities {
 
   public static Map<String, List<FiCaSchedulerAppSchedulingOpportunities>> getAllSchedulingOpportunities()
           throws IOException {
-    LightWeightRequestHandler getSchedulingOpportunitiesHandler
-            = new LightWeightRequestHandler(YARNOperationType.TEST) {
-              @Override
-              public Object performTask() throws StorageException, IOException {
-                connector.beginTransaction();
-                connector.writeLock();
-                FiCaSchedulerAppSchedulingOpportunitiesDataAccess DA
-                = (FiCaSchedulerAppSchedulingOpportunitiesDataAccess) RMStorageFactory.
-                getDataAccess(
-                        FiCaSchedulerAppSchedulingOpportunitiesDataAccess.class);
-                Map<String, List<FiCaSchedulerAppSchedulingOpportunities>> hopSOpp
-                = DA.getAll();
-                connector.commit();
-                return hopSOpp;
-              }
-            };
-    return (Map<String, List<FiCaSchedulerAppSchedulingOpportunities>>) getSchedulingOpportunitiesHandler.
-            handle();
+
+    FiCaSchedulerAppSchedulingOpportunitiesDataAccess DA
+            = (FiCaSchedulerAppSchedulingOpportunitiesDataAccess) RMStorageFactory.
+            getDataAccess(
+                    FiCaSchedulerAppSchedulingOpportunitiesDataAccess.class);
+    return DA.getAll();
+
   }
 
   public static Map<String, List<FiCaSchedulerAppLastScheduledContainer>> getAllLastScheduledContainers()
           throws IOException {
-    LightWeightRequestHandler getLastScheduledContainerHandler
-            = new LightWeightRequestHandler(YARNOperationType.TEST) {
-              @Override
-              public Object performTask() throws StorageException, IOException {
-                connector.beginTransaction();
-                connector.writeLock();
-                FiCaSchedulerAppLastScheduledContainerDataAccess DA
-                = (FiCaSchedulerAppLastScheduledContainerDataAccess) RMStorageFactory.
-                getDataAccess(
-                        FiCaSchedulerAppLastScheduledContainerDataAccess.class);
-                Map<String, List<FiCaSchedulerAppLastScheduledContainer>> hopLastScheduledContainers
-                = DA.getAll();
-                connector.commit();
-                return hopLastScheduledContainers;
-              }
-            };
-    return (Map<String, List<FiCaSchedulerAppLastScheduledContainer>>) getLastScheduledContainerHandler.
-            handle();
+
+    FiCaSchedulerAppLastScheduledContainerDataAccess DA
+            = (FiCaSchedulerAppLastScheduledContainerDataAccess) RMStorageFactory.
+            getDataAccess(
+                    FiCaSchedulerAppLastScheduledContainerDataAccess.class);
+    return DA.getAll();
   }
 
   public static Map<String, List<SchedulerAppReservations>> getAllRereservations()
           throws IOException {
-    LightWeightRequestHandler getReservationsHandler
-            = new LightWeightRequestHandler(YARNOperationType.TEST) {
-              @Override
-              public Object performTask() throws StorageException, IOException {
-                connector.beginTransaction();
-                connector.writeLock();
-                FiCaSchedulerAppReservationsDataAccess DA
-                = (FiCaSchedulerAppReservationsDataAccess) RMStorageFactory.
-                getDataAccess(FiCaSchedulerAppReservationsDataAccess.class);
-                Map<String, List<SchedulerAppReservations>> hopReservationsMap
-                = DA.getAll();
-                connector.commit();
-                return hopReservationsMap;
-              }
-            };
-    return (Map<String, List<SchedulerAppReservations>>) getReservationsHandler.
-            handle();
+    FiCaSchedulerAppReservationsDataAccess DA
+            = (FiCaSchedulerAppReservationsDataAccess) RMStorageFactory.
+            getDataAccess(FiCaSchedulerAppReservationsDataAccess.class);
+    return DA.getAll();
   }
 
   public static Map<String, List<FiCaSchedulerAppReservedContainers>> getAllReservedContainers()
           throws IOException {
-    LightWeightRequestHandler getReservedContainersHandler
-            = new LightWeightRequestHandler(YARNOperationType.TEST) {
-              @Override
-              public Object performTask() throws StorageException, IOException {
-                connector.beginTransaction();
-                connector.writeLock();
-                FiCaSchedulerAppReservedContainersDataAccess DA
-                = (FiCaSchedulerAppReservedContainersDataAccess) RMStorageFactory.
-                getDataAccess(FiCaSchedulerAppReservedContainersDataAccess.class);
-                Map<String, List<FiCaSchedulerAppReservedContainers>> hopResCont
-                = DA.getAll();
-                connector.commit();
-                return hopResCont;
-              }
-            };
-    return (Map<String, List<FiCaSchedulerAppReservedContainers>>) getReservedContainersHandler.
-            handle();
+    FiCaSchedulerAppReservedContainersDataAccess DA
+            = (FiCaSchedulerAppReservedContainersDataAccess) RMStorageFactory.
+            getDataAccess(FiCaSchedulerAppReservedContainersDataAccess.class);
+    return DA.getAll();
   }
 
   public static Map<String, CSQueue> getAllCSQueues() throws IOException {
-    LightWeightRequestHandler handler = new LightWeightRequestHandler(
-            YARNOperationType.TEST) {
-              @Override
-              public Object performTask() throws StorageException, IOException {
-                connector.readCommitted();
-                CSQueueDataAccess csqDA = (CSQueueDataAccess) RMStorageFactory.
-                getDataAccess(CSQueueDataAccess.class);
-                return csqDA.getAll();
-              }
-            };
-    return (Map<String, CSQueue>) handler.handle();
+    CSQueueDataAccess csqDA = (CSQueueDataAccess) RMStorageFactory.
+            getDataAccess(CSQueueDataAccess.class);
+    return csqDA.getAll();
   }
 
   public static Map<String, CSLeafQueueUserInfo> getAllCSLeafQueueUserInfo()
+          throws IOException {
+    CSLeafQueueUserInfoDataAccess csqLUIDA
+            = (CSLeafQueueUserInfoDataAccess) RMStorageFactory.
+            getDataAccess(CSLeafQueueUserInfoDataAccess.class);
+    return csqLUIDA.findAll();
+  }
+
+  public static Map<String, CSLeafQueueUserInfo> getAllCSLeafQueueUserInfoFullTransaction()
           throws IOException {
     LightWeightRequestHandler handler = new LightWeightRequestHandler(
             YARNOperationType.TEST) {
@@ -2654,7 +2448,7 @@ public class RMUtilities {
             };
     return (Map<String, CSLeafQueueUserInfo>) handler.handle();
   }
-
+   
   //for testing
   public static CSQueue getCSQueue(final String queuepath) throws IOException {
     LightWeightRequestHandler getCSQueueInfoHandler

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/AdminService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/AdminService.java
@@ -228,6 +228,7 @@ public class AdminService extends CompositeService
     throw new StandbyException("ResourceManager " + rmId + " is not Active!");
   }
 
+  //TODO redo for distributed version
   @Override
   public synchronized void monitorHealth() throws IOException {
     checkAccess("monitorHealth");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ApplicationMasterService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ApplicationMasterService.java
@@ -705,8 +705,10 @@ public class ApplicationMasterService extends AbstractService
                         getUser(),
                         attemptId,
                         container);
-        LOG.debug("set allocated nm token for: " + attemptId + ", " + nmToken);
-        allocatedNMTokens.add(nmToken);
+        if (nmToken != null) {
+          LOG.debug("set allocated nm token for: " + attemptId + ", " + nmToken);
+          allocatedNMTokens.add(nmToken);
+        }
       }
       allocateResponse.setNMTokens(allocatedNMTokens);
       LOG.debug(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NdbEventStreamingReceiver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NdbEventStreamingReceiver.java
@@ -31,6 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -40,7 +43,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class NdbEventStreamingReceiver {
 
-  //TODO move this to configuration .
+  //TODO move this to configuration and rename properly.
   private static final int experimentCapacity = 100000;
 
   public static BlockingQueue blockingQueue = new ArrayBlockingQueue(
@@ -373,7 +376,11 @@ public class NdbEventStreamingReceiver {
                     hopNodeHBResponse, hopResource,
                     hopPendingEvent, hopJustLaunchedContainersList,
                     hopUpdatedContainerInfoList, hopContainerIdsToCleanList,
-                    hopFinishedApplicationsList, hopContainersStatusList);
+                    hopFinishedApplicationsList, hopContainersStatusList,
+                    hopPendingEvent.getId().getNodeId());
+    LOG.debug("put event in queue: " + hopRMNodeBDBObject.getPendingEvent().
+            getId() + " ; " + hopRMNodeBDBObject.getPendingEvent().getId().
+            getNodeId());
     blockingQueue.put(hopRMNodeBDBObject);
   }
 
@@ -383,11 +390,27 @@ public class NdbEventStreamingReceiver {
             hopNodeHBResponse, hopResource,
             hopPendingEvent, hopJustLaunchedContainersList,
             hopUpdatedContainerInfoList, hopContainerIdsToCleanList,
-            hopFinishedApplicationsList, hopContainersStatusList);
+            hopFinishedApplicationsList, hopContainersStatusList,
+            hopPendingEvent.getId().getNodeId());
   }
 
   public void onEventMethodMultiThread(RMNodeComps hopCompObject) throws
           InterruptedException {
     blockingQueue.put(hopCompObject);
+  }
+
+  public void resetObjects() {
+    hopRMNode = null;
+    hopNextHeartbeat = null;
+    hopNode = null;
+    hopNodeHBResponse = null;
+    hopResource = null;
+    hopPendingEvent = null;
+    hopJustLaunchedContainersList = null;
+    hopUpdatedContainerInfoList = null;
+    hopContainerIdsToCleanList = null;
+    hopFinishedApplicationsList = null;
+    hopContainersStatusList = null;
+
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NdbRtStreamingProcessor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NdbRtStreamingProcessor.java
@@ -63,7 +63,7 @@ public class NdbRtStreamingProcessor implements Runnable {
   public void run() {
     running = true;
     while (running) {
-      if (!context.getRMGroupMembershipService().isLeader()) {
+      if (!context.getGroupMembershipService().isLeader()) {
         try {
 
           StreamingRTComps streamingRTComps = null;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NdbRtStreamingReceiver.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/NdbRtStreamingReceiver.java
@@ -133,4 +133,12 @@ public class NdbRtStreamingReceiver {
           InterruptedException {
     blockingRTQueue.put(streamingRTComps);
   }
+
+  public void resetObjects() {
+    containersToCleanSet = null;
+    finishedAppList = null;
+    nodeId = null;
+    nextHeartbeat = false;
+
+  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/PendingEventRetrievalBatch.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/PendingEventRetrievalBatch.java
@@ -68,45 +68,59 @@ public class PendingEventRetrievalBatch extends PendingEventRetrieval {
     this.writeLock = lock.writeLock();
   }
 
-  @Override
-  public void run() {
-    while (active) {
-      try {
-        long startTime = System.currentTimeMillis();
+  public void start() {
+    if (!active) {
+      active = true;
+      retrivingThread = new Thread(new RetrivingThread());
+      retrivingThread.start();
+    } else {
+      LOG.error("ndb event retriver is already active");
+    }
+  }
+  
+  private class RetrivingThread implements Runnable {
+
+    @Override
+    public void run() {
+      while (active) {
         try {
-          writeLock.lock();
-          //If scheduler just started, retrieve events with status pending 
-          if (firstRetrieval) {
-            pendingEvents.putAll(
-                RMUtilities.getPendingEvents(0, TablesDef.PendingEventTableDef.PENDING));
-            firstRetrieval = false;
-          }
+          long startTime = System.currentTimeMillis();
+          try {
+            writeLock.lock();
+            //If scheduler just started, retrieve events with status pending 
+            if (firstRetrieval) {
+              pendingEvents.putAll(
+                      RMUtilities.getPendingEvents(0,
+                              TablesDef.PendingEventTableDef.PENDING));
+              firstRetrieval = false;
+            }
           //Retrieve all pending events, update their status
-          //to pending and create scheduler events.
-          pendingEvents.putAll(RMUtilities.getAndUpdatePendingEvents(
-              conf.getInt(YarnConfiguration.HOPS_PENDING_EVENTS_BATCH,
-                  YarnConfiguration.DEFAULT_HOPS_PENDING_EVENTS_BATCH),
-              TablesDef.PendingEventTableDef.NEW));
+            //to pending and create scheduler events.
+            pendingEvents.putAll(RMUtilities.getAndUpdatePendingEvents(
+                    conf.getInt(YarnConfiguration.HOPS_PENDING_EVENTS_BATCH,
+                            YarnConfiguration.DEFAULT_HOPS_PENDING_EVENTS_BATCH),
+                    TablesDef.PendingEventTableDef.NEW));
           LOG.debug("HOP :: pending events are:" + pendingEvents.size() + ", " +
               pendingEvents);
-          //Parse all events grouped by RMNode
-          for (String id : pendingEvents.keySet()) {
-            //If this RMNode has not been processed yet
-            if (!pendingNMs.contains(id)) {
-              pendingNMs.add(id);
-              GlobalThreadPool.getExecutorService().
-                  execute(new RMNodeWorker(id));
+            //Parse all events grouped by RMNode
+            for (String id : pendingEvents.keySet()) {
+              //If this RMNode has not been processed yet
+              if (!pendingNMs.contains(id)) {
+                pendingNMs.add(id);
+                GlobalThreadPool.getExecutorService().
+                        execute(new RMNodeWorker(id));
+              }
             }
+          } finally {
+            writeLock.unlock();
           }
-        } finally {
-          writeLock.unlock();
+          Thread.sleep(
+                  Math.max(0, period - (System.currentTimeMillis() - startTime)));
+        } catch (IOException ex) {
+          LOG.error("HOP :: Error while retrieving PendingEvents", ex);
+        } catch (InterruptedException ex) {
+          LOG.error("HOP :: Error while retrieving PendingEvents", ex);
         }
-        Thread.sleep(
-            Math.max(0, period - (System.currentTimeMillis() - startTime)));
-      } catch (IOException ex) {
-        LOG.error("HOP :: Error while retrieving PendingEvents", ex);
-      } catch (InterruptedException ex) {
-        LOG.error("HOP :: Error while retrieving PendingEvents", ex);
       }
     }
   }
@@ -129,7 +143,8 @@ public class PendingEventRetrievalBatch extends PendingEventRetrieval {
       LOG.debug("HOP :: RMNodeWorker:" + id + " - START");
       try {
         //Retrieve RMNode
-        rmNode = processHopRMNodeComps(RMUtilities.getRMNodeBatch(id));
+        rmNode = RMUtilities.processHopRMNodeCompsForScheduler(RMUtilities.
+                getRMNodeBatch(id), rmContext);
         LOG.debug("HOP :: RMNodeWorker rmNode:" + rmNode);
       } catch (IOException ex) {
         LOG.error("HOP :: Error retrieving rmNode:" + id, ex);
@@ -144,7 +159,7 @@ public class PendingEventRetrievalBatch extends PendingEventRetrieval {
           ConcurrentSkipListSet<PendingEvent> eventsToRemove = pendingEvents.
               get(id);
           for (PendingEvent pendingEvent : eventsToRemove) {
-            triggerEvent(rmNode, pendingEvent);
+            triggerEvent(rmNode, pendingEvent, false);
           }
           try {
             writeLock.lock();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContext.java
@@ -51,6 +51,8 @@ public interface RMContext extends Recoverable {
 
   boolean isHAEnabled();
 
+  boolean isDistributedEnabled();
+  
   HAServiceState getHAServiceState();
 
   RMStateStore getStateStore();
@@ -85,7 +87,7 @@ public interface RMContext extends Recoverable {
 
   AdminService getRMAdminService();
 
-  GroupMembershipService getRMGroupMembershipService();
+  GroupMembershipService getGroupMembershipService();
   
   ClientRMService getClientRMService();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContextImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/RMContextImpl.java
@@ -97,6 +97,7 @@ public class RMContextImpl implements RMContext {
       new ConcurrentHashMap<String, RMNode>();
       //recovered, pushed and removed everywhere
   private boolean isHAEnabled; //recovered through configuration file
+  private boolean isDistributedEnabled;
   private HAServiceState haServiceState =
       HAServiceProtocol.HAServiceState.INITIALIZING; //recovered
   private AMLivelinessMonitor amLivelinessMonitor;//recovered
@@ -292,7 +293,7 @@ public class RMContextImpl implements RMContext {
   }
 
   @Override
-  public GroupMembershipService getRMGroupMembershipService() {
+  public GroupMembershipService getGroupMembershipService() {
     return this.groupMembershipService;
   }
 
@@ -320,6 +321,10 @@ public class RMContextImpl implements RMContext {
     this.isHAEnabled = isHAEnabled;
   }
 
+  void setDistributedEnabled(boolean isDistributedEnabled){
+    this.isDistributedEnabled = isDistributedEnabled;
+  }
+  
   void setHAServiceState(HAServiceState haServiceState) {
     synchronized (haServiceState) {
       this.haServiceState = haServiceState;
@@ -423,6 +428,11 @@ public class RMContextImpl implements RMContext {
     return isHAEnabled;
   }
 
+  @Override
+  public boolean isDistributedEnabled(){
+    return isDistributedEnabled;
+  }
+  
   @Override
   public HAServiceState getHAServiceState() {
     synchronized (haServiceState) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceManager.java
@@ -21,6 +21,7 @@ import io.hops.common.GlobalThreadPool;
 import io.hops.ha.common.TransactionStateManager;
 import io.hops.metadata.util.RMStorageFactory;
 import io.hops.metadata.util.YarnAPIStorageFactory;
+import io.hops.metadata.yarn.entity.PendingEvent;
 import io.hops.metadata.yarn.entity.appmasterrpc.RPC;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -158,7 +159,7 @@ public class ResourceManager extends CompositeService implements Recoverable {
    * in
    * Active state.
    */
-  protected RMActiveServices activeServices;
+  protected RMSchedulerServices schedulerServices;
   protected RMSecretManagerService rmSecretManagerService;
 
   protected ResourceScheduler scheduler;//recovered
@@ -175,11 +176,11 @@ public class ResourceManager extends CompositeService implements Recoverable {
 
   private String webAppAddress;
   private ConfigurationProvider configurationProvider = null;
-  PendingEventRetrieval retrievalThread;
+  PendingEventRetrieval eventRetriever;
   private ContainerAllocationExpirer containerAllocationExpirer;
   private boolean recoveryEnabled;
   private DelegationTokenRenewer delegationTokenRenewer;
-
+  private CompositeService resourceTrackingService;
   /**
    * End of Active services
    */
@@ -205,93 +206,15 @@ public class ResourceManager extends CompositeService implements Recoverable {
     clusterTimeStamp = timestamp;
   }
 
-  /**
-   * Starts the services required by the ResourceTracker machines when
-   * DistributedRT is enabled.
-   *
-   * @throws Exception
-   */
-  private void initDistributedRTServices(CompositeService service)
-      throws Exception {
-    conf.setBoolean(Dispatcher.DISPATCHER_EXIT_ON_ERROR_KEY, true);
-
-    rmSecretManagerService = createRMSecretManagerService();
-    service.addService(rmSecretManagerService);
-
-    containerAllocationExpirer = new ContainerAllocationExpirer(rmDispatcher,
-            rmContext);
-    service.addService(containerAllocationExpirer);
-    rmContext.setContainerAllocationExpirer(containerAllocationExpirer);
-
-    AMLivelinessMonitor amLivelinessMonitor = createAMLivelinessMonitor();
-    service.addService(amLivelinessMonitor);
-    rmContext.setAMLivelinessMonitor(amLivelinessMonitor);
-
-    AMLivelinessMonitor amFinishingMonitor = createAMLivelinessMonitor();
-    service.addService(amFinishingMonitor);
-    rmContext.setAMFinishingMonitor(amFinishingMonitor);
-
-    boolean isRecoveryEnabled =
-        conf.getBoolean(YarnConfiguration.RECOVERY_ENABLED,
-            YarnConfiguration.DEFAULT_RM_RECOVERY_ENABLED);
-
-    RMStateStore rmStore = null;
-    if (isRecoveryEnabled) {
-      LOG.info("recovery enabled");
-      recoveryEnabled = true;
-      rmStore = RMStateStoreFactory.getStore(conf);
-    } else {
-      recoveryEnabled = false;
-      rmStore = new NullRMStateStore();
-    }
-
-    try {
-      rmStore.init(conf);
-      rmStore.setRMDispatcher(rmDispatcher);
-    } catch (Exception e) {
-      // the Exception from stateStore.init() needs to be handled for
-      // HA and we need to give up master status if we got fenced
-      LOG.error("Failed to init state store", e);
-      throw e;
-    }
-    rmContext.setStateStore(rmStore);
-
-    if (UserGroupInformation.isSecurityEnabled()) {
-      delegationTokenRenewer = createDelegationTokenRenewer();
-      rmContext.setDelegationTokenRenewer(delegationTokenRenewer);
-    }
-
-    RMApplicationHistoryWriter rmApplicationHistoryWriter =
-        createRMApplicationHistoryWriter();
-    service.addService(rmApplicationHistoryWriter);
-    rmContext.setRMApplicationHistoryWriter(rmApplicationHistoryWriter);
-
-    // Register event handler for NodesListManager
-    nodesListManager = new NodesListManager(rmContext);
-    rmDispatcher.register(NodesListManagerEventType.class, nodesListManager);
-    service.addService(nodesListManager);
-    rmContext.setNodesListManager(nodesListManager);
-
-    // Register event handler for RmNodes
-    rmDispatcher
-        .register(RMNodeEventType.class, new NodeEventDispatcher(rmContext));
-
-    nmLivelinessMonitor = createNMLivelinessMonitor();
-    service.addService(nmLivelinessMonitor);
-
-    resourceTracker = createResourceTrackerService();
-    service.addService(resourceTracker);
-    rmContext.setResourceTrackerService(resourceTracker);
-
-    DefaultMetricsSystem.initialize("ResourceManager");
-    JvmMetrics.initSingleton("ResourceManager", null);
-  }
-
   @Override
   protected void serviceInit(Configuration conf) throws Exception {
     this.conf = conf;
     this.rmContext = new RMContextImpl();
 
+    this.rmContext.setDistributedEnabled(conf.getBoolean(
+            YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
+            YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+    
     transactionStateManager = new TransactionStateManager();
     addIfService(transactionStateManager);
     rmContext.setTransactionStateManager(transactionStateManager);
@@ -351,12 +274,8 @@ public class ResourceManager extends CompositeService implements Recoverable {
 
     this.rmLoginUGI = UserGroupInformation.getCurrentUser();
 
-    //If distributed RT is enabled start the services of the non-leader machines
-    if (conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-        YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
-      initDistributedRTServices(this);
-    }
-    createAndInitActiveServices();
+    createAndInitSchedulerServices();
+    
     super.serviceInit(this.conf);
   }
 
@@ -365,9 +284,11 @@ public class ResourceManager extends CompositeService implements Recoverable {
     return new QueueACLsManager(scheduler, conf);
   }
 
+  boolean rmStoreBlocked=false;
   @VisibleForTesting
   protected void setRMStateStore(RMStateStore rmStore) {
     rmStore.setRMDispatcher(rmDispatcher);
+    rmStoreBlocked=true;
     rmContext.setStateStore(rmStore);
   }
 
@@ -453,29 +374,127 @@ public class ResourceManager extends CompositeService implements Recoverable {
     }
   }
 
+  
+  @Private
+  class ResourceTrackingServices extends CompositeService {
+
+    public ResourceTrackingServices() {
+      super("ResourceTrackingServices");
+      LOG.info("create resourceTrackingService");
+    }
+    
+    @Override
+    protected void serviceInit(Configuration configuration) throws Exception {
+      LOG.info("init resourceTrackingService");
+      conf.setBoolean(Dispatcher.DISPATCHER_EXIT_ON_ERROR_KEY, true);
+
+      if (!rmStoreBlocked) {
+        RMStateStore rmStore = null;
+        if (recoveryEnabled) {
+          rmStore = RMStateStoreFactory.getStore(conf);
+        } else {
+          rmStore = new NullRMStateStore();
+        }
+
+        try {
+          rmStore.init(conf);
+          rmStore.setRMDispatcher(rmDispatcher);
+        } catch (Exception e) {
+      // the Exception from stateStore.init() needs to be handled for
+          // HA and we need to give up master status if we got fenced
+          LOG.error("Failed to init state store", e);
+          throw e;
+        }
+        rmContext.setStateStore(rmStore);
+      }
+      
+      rmSecretManagerService = createRMSecretManagerService();
+      this.addService(rmSecretManagerService);
+
+      containerAllocationExpirer = new ContainerAllocationExpirer(rmDispatcher,
+              rmContext);
+      this.addService(containerAllocationExpirer);
+      rmContext.setContainerAllocationExpirer(containerAllocationExpirer);
+
+      AMLivelinessMonitor amLivelinessMonitor = createAMLivelinessMonitor();
+      this.addService(amLivelinessMonitor);
+      rmContext.setAMLivelinessMonitor(amLivelinessMonitor);
+
+      AMLivelinessMonitor amFinishingMonitor = createAMLivelinessMonitor();
+      this.addService(amFinishingMonitor);
+      rmContext.setAMFinishingMonitor(amFinishingMonitor);
+
+      boolean isRecoveryEnabled = conf.getBoolean(
+              YarnConfiguration.RECOVERY_ENABLED,
+              YarnConfiguration.DEFAULT_RM_RECOVERY_ENABLED);
+
+      if (isRecoveryEnabled) {
+        LOG.info("recovery enabled");
+        recoveryEnabled = true;
+      } else {
+        recoveryEnabled = false;
+      }
+
+      if (UserGroupInformation.isSecurityEnabled()) {
+        delegationTokenRenewer = createDelegationTokenRenewer();
+        rmContext.setDelegationTokenRenewer(delegationTokenRenewer);
+      }
+
+      RMApplicationHistoryWriter rmApplicationHistoryWriter
+              = createRMApplicationHistoryWriter();
+      this.addService(rmApplicationHistoryWriter);
+      rmContext.setRMApplicationHistoryWriter(rmApplicationHistoryWriter);
+
+      // Register event handler for NodesListManager
+      nodesListManager = new NodesListManager(rmContext);
+      rmDispatcher.register(NodesListManagerEventType.class, nodesListManager);
+      this.addService(nodesListManager);
+      rmContext.setNodesListManager(nodesListManager);
+
+      // Register event handler for RmNodes
+      rmDispatcher
+              .register(RMNodeEventType.class,
+                      new NodeEventDispatcher(rmContext));
+
+      nmLivelinessMonitor = createNMLivelinessMonitor();
+      this.addService(nmLivelinessMonitor);
+
+      resourceTracker = createResourceTrackerService();
+      this.addService(resourceTracker);
+      rmContext.setResourceTrackerService(resourceTracker);
+
+      DefaultMetricsSystem.initialize("ResourceManager");
+      JvmMetrics.initSingleton("ResourceManager", null);
+      
+      super.serviceInit(conf);
+    }
+    
+    @Override
+    protected void serviceStart() throws Exception {
+      LOG.info("starting resourceTrackingService");
+      super.serviceStart();
+    }
+  }
+  
+  
   /**
-   * RMActiveServices handles all the Active services in the RM.
+   * RMSchedulerServices handles all the services run by the Scheduler node.
    */
   @Private
-  class RMActiveServices extends CompositeService {
+  class RMSchedulerServices extends CompositeService {
 
     private EventHandler<SchedulerEvent> schedulerDispatcher;
     private ApplicationMasterLauncher applicationMasterLauncher;
 
 
-    RMActiveServices() {
+    RMSchedulerServices() {
       super("RMActiveServices");
     }
 
     @Override
     protected void serviceInit(Configuration configuration) throws Exception {
-
-      //If distributed RT is disabeld and I become leader, start the services
-      //that are by-default started by the non-leader machines 
-      if (!conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-          YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
-        initDistributedRTServices(this);
-      }
+      
+      createAndInitResourceTrackingServices();
       // Initialize the scheduler
       scheduler = createScheduler();
       rmContext.setScheduler(scheduler);
@@ -534,8 +553,18 @@ public class ResourceManager extends CompositeService implements Recoverable {
       super.serviceInit(conf);
     }
 
+    private void startDispatchers(){
+      if (schedulerDispatcher instanceof Service) {
+        ((Service)schedulerDispatcher).start();
+      }
+      if(rmDispatcher instanceof Service){
+        ((Service)rmDispatcher).start();
+      }
+    }
+    
     @Override
     protected void serviceStart() throws Exception {
+      LOG.info("start schedulerServices");
       RMStateStore rmStore = rmContext.getStateStore();
       // The state store needs to start irrespective of recoveryEnabled as apps
       // need events to move to further states.
@@ -545,6 +574,8 @@ public class ResourceManager extends CompositeService implements Recoverable {
         try {
           rmStore.checkVersion();
           RMState state = rmStore.loadState(rmContext);
+          //the dispatchers should be started to recover the RPCs.
+          startDispatchers();
           recover(state);
         } catch (Exception e) {
           // the Exception from loadState() needs to be handled for
@@ -553,18 +584,21 @@ public class ResourceManager extends CompositeService implements Recoverable {
           throw e;
         }
       }
+      resourceTrackingService.start();
       super.serviceStart();
     }
 
     @Override
     protected void serviceStop() throws Exception {
-
+      LOG.info("stop schedulerServices");
       DefaultMetricsSystem.shutdown();
 
       if (rmContext != null) {
         RMStateStore store = rmContext.getStateStore();
         try {
-          store.close();
+          if(!rmStoreBlocked){
+            store.close();
+          }
         } catch (Exception e) {
           LOG.error("Error closing store.", e);
         }
@@ -888,52 +922,58 @@ public class ResourceManager extends CompositeService implements Recoverable {
 
   /**
    * Helper method to create and init {@link #activeServices}. This creates an
-   * instance of {@link RMActiveServices} and initializes it.
+   * instance of {@link RMSchedulerServices} and initializes it.
    *
    * @throws Exception
    */
-  void createAndInitActiveServices() throws Exception {
-    activeServices = new RMActiveServices();
-    activeServices.init(conf);
+  void createAndInitSchedulerServices() throws Exception {
+    schedulerServices = new RMSchedulerServices();
+    schedulerServices.init(conf);
   }
 
+  void createAndInitResourceTrackingServices() {
+    resourceTrackingService = new ResourceTrackingServices();
+    resourceTrackingService.init(conf);
+  }
+  
   /**
    * Helper method to start {@link #activeServices}.
    *
    * @throws Exception
    */
-  void startActiveServices() throws Exception {
-    if (activeServices != null) {
+  void startSchedulerServices() throws Exception {
+    if (schedulerServices != null) {
       clusterTimeStamp = System.currentTimeMillis();
-      activeServices.start();
-
+      schedulerServices.start(); 
       
     }
   }
-
+  
   /**
    * Helper method to stop {@link #activeServices}.
    *
    * @throws Exception
    */
-  void stopActiveServices() throws Exception {
-    if (activeServices != null) {
-      activeServices.stop();
-      activeServices = null;
+  void stopSchedulerServices() throws Exception {
+    if (schedulerServices != null) {
+      schedulerServices.stop();
+      schedulerServices = null;
       rmContext.getActiveRMNodes().clear();//we should not update the db here 
       rmContext.getInactiveRMNodes().clear();//we should not update the db here 
       rmContext.getRMApps().clear();//we should not update the db here 
       ClusterMetrics.destroy();
       QueueMetrics.clearQueueMetrics();
-      if (retrievalThread != null) {
-        retrievalThread.finish();
+      //TODO should probably not be there anymore
+      if (eventRetriever != null) {
+        LOG.info("NDB Event streaming is stoping now ..");
+        eventRetriever.finish();
       }
     }
   }
 
   @VisibleForTesting
   protected boolean areActiveServicesRunning() {
-    return activeServices != null && activeServices.isInState(STATE.STARTED);
+    return schedulerServices != null && schedulerServices.isInState(STATE.STARTED);
   }
 
   synchronized void transitionToActive() throws Exception {
@@ -945,14 +985,30 @@ public class ResourceManager extends CompositeService implements Recoverable {
 
     LOG.info("Transitioning to active state " + groupMembershipService.
         getHostname());
-
+    
+    stopSchedulerServices();
+    resourceTrackingService.stop();
+    resetDispatcher();
+    resetTransactionStateManager();  
+    createAndInitSchedulerServices();  
+    if (rmContext.isDistributedEnabled()) {
+      if (conf.getBoolean(YarnConfiguration.HOPS_NDB_EVENT_STREAMING_ENABLED,
+              YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
+        LOG.info("streaming porcessor is straring for scheduler");
+          RMStorageFactory.kickTheNdbEventStreamingAPI(true);
+//        }
+        eventRetriever = new NdbEventStreamingProcessor(rmContext, conf);
+      } else {
+        eventRetriever = new PendingEventRetrievalBatch(rmContext, conf);
+      }
+    }
     // use rmLoginUGI to startActiveServices.
     // in non-secure model, rmLoginUGI will be current UGI
     // in secure model, rmLoginUGI will be LoginUser UGI
     this.rmLoginUGI.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
       public Void run() throws Exception {
-        startActiveServices();
+        startSchedulerServices();
         return null;
       }
     });
@@ -962,22 +1018,8 @@ public class ResourceManager extends CompositeService implements Recoverable {
         getHostname());
     //Start PendingEvent retrieval thread
     //Start periodic retrieval of pending scheduler events
-    if (conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-        YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
-    if (conf.getBoolean(YarnConfiguration.HOPS_NDB_EVENT_STREAMING_ENABLED,
-              YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
-        if (!conf.getBoolean(
-                YarnConfiguration.HOPS_NDB_RT_EVENT_STREAMING_ENABLED,
-                YarnConfiguration.DEFAULT_HOPS_NDB_RT_EVENT_STREAMING_ENABLED)) {
-          LOG.info("HOP :: NDB Event streaming is starting now ..");
-          RMStorageFactory.kickTheNdbEventStreamingAPI();
-        }
-        retrievalThread = new NdbEventStreamingProcessor(rmContext, conf);
-      } else {
-        LOG.debug("HOP :: Starting PendingEvent retrieval thread");
-        retrievalThread = new PendingEventRetrievalBatch(rmContext, conf);
-      }
-      GlobalThreadPool.getExecutorService().execute(retrievalThread);
+    if (rmContext.isDistributedEnabled()) {
+      eventRetriever.start();
     }
   }
 
@@ -994,14 +1036,18 @@ public class ResourceManager extends CompositeService implements Recoverable {
             getHostname());
     if (rmContext.getHAServiceState() ==
         HAServiceProtocol.HAServiceState.ACTIVE) {
-      stopActiveServices();
+      stopSchedulerServices();
+      resourceTrackingService.stop();
       if (groupMembershipService.isLeader()) {
         groupMembershipService.relinquishId();
       }
       if (initialize) {
         resetDispatcher();
         resetTransactionStateManager();
-        createAndInitActiveServices();
+        createAndInitSchedulerServices();
+        if(rmContext.isDistributedEnabled()){
+          resourceTrackingService.start();
+        }
       }
     }
     rmContext.setHAServiceState(HAServiceProtocol.HAServiceState.STANDBY);
@@ -1034,6 +1080,9 @@ public class ResourceManager extends CompositeService implements Recoverable {
       int port = webApp.port();
       WebAppUtils.setRMWebAppPort(conf, port);
     }
+    if (rmContext.isDistributedEnabled()) {
+      resourceTrackingService.start();
+    }
     super.serviceStart();
   }
 
@@ -1058,6 +1107,9 @@ public class ResourceManager extends CompositeService implements Recoverable {
     }
     if (configurationProvider != null) {
       configurationProvider.close();
+    }
+    if (resourceTrackingService != null) {
+      resourceTrackingService.stop();
     }
     super.serviceStop();
     LOG.info("transition to standby serviceStop");
@@ -1154,6 +1206,9 @@ public class ResourceManager extends CompositeService implements Recoverable {
 
     //recover not finished rpc
     try {
+      LOG.info("recover pending events");
+      recoverPendingEvents(state);
+      LOG.info("recover RPCs");
       recoverRpc(state);
     } catch (YarnException ex) {
       //TODO see what to do with this exceptions
@@ -1174,6 +1229,22 @@ public class ResourceManager extends CompositeService implements Recoverable {
     return ugi;
   }
 
+  protected void recoverPendingEvents(RMState rmState) throws IOException {
+    List<PendingEvent> pendingEvents = rmState.getPendingEvents();
+    if (!pendingEvents.isEmpty()) {
+      Collections.sort(pendingEvents);
+    }
+    for (final PendingEvent pendingEvent : pendingEvents) {
+      //the rmnode should already have been recovered
+      NodeId nodeId = ConverterUtils.toNodeId(pendingEvent.getId().getNodeId());
+
+      RMNode rmNode = rmContext.getActiveRMNodes().get(nodeId);
+      LOG.debug("recover pending event for node " + nodeId
+              + " of type " + pendingEvent.getType() + "rmNode " + rmNode);
+      eventRetriever.triggerEvent(rmNode, pendingEvent, true);
+    }
+  }
+  
   protected void recoverRpc(RMState rmState) throws IOException, YarnException {
     List<RPC> rpcList = rmState.getAppMasterRPCs();
     if(!rpcList.isEmpty()){
@@ -1275,22 +1346,24 @@ public class ResourceManager extends CompositeService implements Recoverable {
                 });
             break;
           case RegisterNM:
-            proto =
-                YarnServerCommonServiceProtos.RegisterNodeManagerRequestProto.
-                    parseFrom(rpc.getRpc());
-            resourceTracker.registerNodeManager(
-                new RegisterNodeManagerRequestPBImpl(
-                    (YarnServerCommonServiceProtos.RegisterNodeManagerRequestProto) proto),
-                rpc.getRPCId(),
-                conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                    YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+            if (!rmContext.isDistributedEnabled()) {
+              proto
+                      = YarnServerCommonServiceProtos.RegisterNodeManagerRequestProto.
+                      parseFrom(rpc.getRpc());
+              resourceTracker.registerNodeManager(
+                      new RegisterNodeManagerRequestPBImpl(
+                              (YarnServerCommonServiceProtos.RegisterNodeManagerRequestProto) proto),
+                      rpc.getRPCId());
+            }
             break;
           case NodeHeartbeat:
-            proto = YarnServerCommonServiceProtos.NodeHeartbeatRequestProto.
-                parseFrom(rpc.getRpc());
-            resourceTracker.nodeHeartbeat(new NodeHeartbeatRequestPBImpl(
-                    (YarnServerCommonServiceProtos.NodeHeartbeatRequestProto) proto),
-                rpc.getRPCId());
+            if (!rmContext.isDistributedEnabled()) {
+              proto = YarnServerCommonServiceProtos.NodeHeartbeatRequestProto.
+                      parseFrom(rpc.getRpc());
+              resourceTracker.nodeHeartbeat(new NodeHeartbeatRequestPBImpl(
+                      (YarnServerCommonServiceProtos.NodeHeartbeatRequestProto) proto),
+                      rpc.getRPCId());
+            }
             break;
           default:
             LOG.error("RPC type does not exist");
@@ -1355,6 +1428,8 @@ public class ResourceManager extends CompositeService implements Recoverable {
   }
 
   private void resetTransactionStateManager(){
+    LOG.info("reset transactionStateManager");
+    transactionStateManager.stop();
     TransactionStateManager tsm = new TransactionStateManager();
     ((Service) tsm).init(conf);
     ((Service) tsm).start();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ResourceTrackerService.java
@@ -151,14 +151,10 @@ public class ResourceTrackerService extends AbstractService
             YarnConfiguration.RM_NODEMANAGER_MINIMUM_VERSION,
             YarnConfiguration.DEFAULT_RM_NODEMANAGER_MINIMUM_VERSION);
 
-    if (conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-            YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
+    if (rmContext.isDistributedEnabled()) {
       if (conf.getBoolean(YarnConfiguration.HOPS_NDB_RT_EVENT_STREAMING_ENABLED,
               YarnConfiguration.DEFAULT_HOPS_NDB_RT_EVENT_STREAMING_ENABLED)) {
-        LOG.info("Resource tracker streaming porcessor is straring ...");
-        RMStorageFactory.kickTheNdbEventStreamingAPI();
         rtStreamingProcessor = new NdbRtStreamingProcessor(rmContext);
-        new Thread(rtStreamingProcessor).start();
       }
 
     }
@@ -175,6 +171,18 @@ public class ResourceTrackerService extends AbstractService
     LOG.debug(
             "starting ResourceTrackerService server on "
             + resourceTrackerAddress);
+    
+    if (rmContext.isDistributedEnabled() && !rmContext.
+            getGroupMembershipService().isLeader()) {
+      if (conf.getBoolean(YarnConfiguration.HOPS_NDB_RT_EVENT_STREAMING_ENABLED,
+              YarnConfiguration.DEFAULT_HOPS_NDB_RT_EVENT_STREAMING_ENABLED)) {
+        LOG.info("streaming porcessor is straring for resource tracker");
+        RMStorageFactory.kickTheNdbEventStreamingAPI(false);
+        new Thread(rtStreamingProcessor).start();
+      }
+
+    }
+    
     this.server = rpc.getServer(ResourceTracker.class, this,
             resourceTrackerAddress, conf,
             null, conf.getInt(
@@ -202,6 +210,8 @@ public class ResourceTrackerService extends AbstractService
 
   @Override
   protected void serviceStop() throws Exception {
+    LOG.info("stopping ResourceTrackerService server on "
+            + resourceTrackerAddress);
     if (this.server != null) {
       this.server.stop();
     }
@@ -264,14 +274,13 @@ public class ResourceTrackerService extends AbstractService
   @Override
   public RegisterNodeManagerResponse registerNodeManager(
           RegisterNodeManagerRequest request) throws YarnException, IOException {
-    return registerNodeManager(request, null,
-            conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                    YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+    return registerNodeManager(request, null);
   }
 
   public RegisterNodeManagerResponse registerNodeManager(
-          RegisterNodeManagerRequest request, Integer rpcID,
-          boolean isDistributedRTEnabled) throws YarnException, IOException {
+          RegisterNodeManagerRequest request, Integer rpcID) 
+          throws YarnException, IOException {
+    
     RegisterNodeManagerResponse response = recordFactory.newRecordInstance(
             RegisterNodeManagerResponse.class);
     NodeId nodeId = request.getNodeId();
@@ -354,15 +363,14 @@ public class ResourceTrackerService extends AbstractService
             resolve(host),
             ResourceOption.newInstance(capability,
                     RMNode.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT),
-            nodeManagerVersion,
-            conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                    YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+            nodeManagerVersion);
 
     int pendingEventId = ((TransactionStateImpl) transactionState)
             .getRMNodeInfo(nodeId).getPendingId();
-    if (isDistributedRTEnabled) {
+    if (rmContext.isDistributedEnabled()) {
       if (!oldNodeExists) {
-        LOG.info("HOP :: Registering new node at: " + host);
+        LOG.info("HOP :: Registering new node at: " + host + " nodeId " +
+                nodeId);
         this.rmContext.getActiveRMNodes().put(nodeId, rmNode);
         ((TransactionStateImpl) transactionState).getRMContextInfo().
                 toAddActiveRMNode(nodeId, rmNode, pendingEventId);
@@ -377,10 +385,9 @@ public class ResourceTrackerService extends AbstractService
         LOG.info("Reconnect from the node at: " + host);
         this.nmLivelinessMonitor.unregister(nodeId);
         load--;
-        if (conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
+        if (rmContext.isDistributedEnabled()) {
           ((TransactionStateImpl) transactionState).getRMContextInfo().
-                  updateLoad(rmContext.getRMGroupMembershipService().
+                  updateLoad(rmContext.getGroupMembershipService().
                           getHostname(), load);
         }
         this.rmContext.getDispatcher().getEventHandler()
@@ -405,10 +412,9 @@ public class ResourceTrackerService extends AbstractService
         LOG.info("Reconnect from the node at: " + host);
         this.nmLivelinessMonitor.unregister(nodeId);
         load--;
-        if (conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-                YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
+        if (rmContext.isDistributedEnabled()) {
           ((TransactionStateImpl) transactionState).getRMContextInfo().
-                  updateLoad(rmContext.getRMGroupMembershipService().
+                  updateLoad(rmContext.getGroupMembershipService().
                           getHostname(), load);
         }
         this.rmContext.getDispatcher().getEventHandler()
@@ -422,10 +428,9 @@ public class ResourceTrackerService extends AbstractService
     this.nmTokenSecretManager.removeNodeKey(nodeId);
     this.nmLivelinessMonitor.register(nodeId);
     load++;
-    if (conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-            YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED)) {
+    if (rmContext.isDistributedEnabled()) {
       ((TransactionStateImpl) transactionState).getRMContextInfo()
-              .updateLoad(rmContext.getRMGroupMembershipService().getHostname(),
+              .updateLoad(rmContext.getGroupMembershipService().getHostname(),
                       load);
     }
     String message = "NodeManager from node " + host + "(cmPort: " + cmPort
@@ -451,8 +456,7 @@ public class ResourceTrackerService extends AbstractService
 
   public NodeHeartbeatResponse nodeHeartbeat(NodeHeartbeatRequest request,
           Integer rpcID) throws YarnException, IOException {
-    //TODO HOPS: If the RMNode is unknown, fetch from NDB first
-    
+
     NodeStatus remoteNodeStatus = request.getNodeStatus();
     NodeId nodeId = remoteNodeStatus.getNodeId();
 
@@ -468,6 +472,14 @@ public class ResourceTrackerService extends AbstractService
      */
     RMNode rmNode = this.rmContext.getActiveRMNodes().get(nodeId);
     // 1. Check if it's a registered node
+    if (rmContext.isDistributedEnabled() && rmNode == null) {
+      LOG.info("never saw this node " + nodeId + " geting it from db");
+      rmNode = RMUtilities.getRMNode(nodeId.toString(), rmContext, conf);
+      if (rmNode != null) {
+        this.rmContext.getActiveRMNodes().put(nodeId, rmNode);
+        this.nmLivelinessMonitor.register(nodeId);
+      }
+    }
     if (rmNode == null) {
       /*
        * node does not exist
@@ -511,6 +523,23 @@ public class ResourceTrackerService extends AbstractService
     // 3. Check if it's a 'fresh' heartbeat i.e. not duplicate heartbeat
     NodeHeartbeatResponse lastNodeHeartbeatResponse = rmNode.
             getLastNodeHeartBeatResponse();
+    if (rmContext.isDistributedEnabled() && 
+            lastNodeHeartbeatResponse.getResponseId() < remoteNodeStatus.
+            getResponseId()) {
+      LOG.info("my view of " + nodeId
+              + " is outdated lastNodeHeartbeatResponse: "
+              + lastNodeHeartbeatResponse.getResponseId()
+              + "hb: " + remoteNodeStatus.getResponseId() + " fetching from db");
+      rmNode = RMUtilities.getRMNode(nodeId.toString(), rmContext, conf);
+      if (rmNode != null) {
+        this.rmContext.getActiveRMNodes().put(nodeId, rmNode);
+        this.nmLivelinessMonitor.register(nodeId);
+      }
+      if (lastNodeHeartbeatResponse.getResponseId() < remoteNodeStatus.
+            getResponseId()) {
+        //TODO recover rpc?
+      }
+    }
     if (remoteNodeStatus.getResponseId() + 1 == lastNodeHeartbeatResponse.
             getResponseId()) {
       LOG.info(
@@ -541,7 +570,6 @@ public class ResourceTrackerService extends AbstractService
                     getResponseId() + 1, NodeAction.NORMAL, null, null, null,
                     null,
                     nextHeartBeatInterval);
-
     rmNode.updateNodeHeartbeatResponseForCleanup(nodeHeartBeatResponse,
             transactionState);
     nodeHeartBeatResponse.setNextheartbeat(((RMNodeImpl) rmNode).

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
@@ -30,6 +30,7 @@ import io.hops.metadata.yarn.entity.FiCaSchedulerNode;
 import io.hops.metadata.yarn.entity.JustLaunchedContainers;
 import io.hops.metadata.yarn.entity.LaunchedContainers;
 import io.hops.metadata.yarn.entity.Node;
+import io.hops.metadata.yarn.entity.PendingEvent;
 import io.hops.metadata.yarn.entity.QueueMetrics;
 import io.hops.metadata.yarn.entity.RMContainer;
 import io.hops.metadata.yarn.entity.RMContextActiveNodes;
@@ -131,7 +132,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
   protected static final String DELEGATION_TOKEN_SEQUENCE_NUMBER_PREFIX =
       "RMDTSequenceNumber_";
   protected static final String VERSION_NODE = "RMVersionNode";
-  private static boolean isDistributedRTEnabled;
   
   public static final Log LOG = LogFactory.getLog(RMStateStore.class);
 
@@ -381,6 +381,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
 
     Map<KeyType, MasterKey> secretMamagerKeys;
     List<RPC> appMasterRPCs;
+    List<PendingEvent> pendingEvents;
     Map<String, AppSchedulingInfo> appSchedulingInfos;
     Map<String, SchedulerApplication> schedulerApplications;
     Map<String, FiCaSchedulerNode> fiCaSchedulerNodes;
@@ -446,6 +447,14 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
       }
     }
 
+    public List<PendingEvent> getPendingEvents() throws IOException {
+      if (pendingEvents != null) {
+        return pendingEvents;
+      } else {
+        return Collections.EMPTY_LIST;
+      }
+    }
+    
     public AppSchedulingInfo getAppSchedulingInfo(final String appId)
         throws IOException {
       return appSchedulingInfos.get(appId);
@@ -570,11 +579,19 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
               node.setLevel(hopNode.getLevel());
             }
             //Get NextHeartbeat
-            boolean nextHeartbeat =
-                allRMNodeNextHeartbeats.get(hopRMContextNode.
+            LOG.debug("nexthb: " + allRMNodeNextHeartbeats
+                    + " hopRMContextNode: " + hopRMContextNode + " getNodeId: "
+                    + hopRMContextNode.
                     getNodeId());
-            LOG.debug("HOP :: RMStateStore-node:" + hopRMContextNode.
-                getNodeId() + ", nextHB:" + nextHeartbeat);
+            boolean nextHeartbeat = false;
+            if (allRMNodeNextHeartbeats.get(hopRMContextNode.getNodeId())
+                    != null) {
+              nextHeartbeat = true;
+            }
+
+            LOG.info("HOP :: RMStateStore-node:" + hopRMContextNode.
+                    getNodeId() + ", state:" + hopRMNode.getCurrentState()
+                    + " resources: " + res);
             org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode rmNode =
                 new RMNodeImpl(nodeId, rmContext, hopRMNode.getHostName(),
                     hopRMNode.getCommandPort(), hopRMNode.getHttpPort(), node,
@@ -585,8 +602,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
                         hopRMNode.getOvercommittimeout()),
                     hopRMNode.getNodemanagerVersion(),
                     hopRMNode.getHealthReport(),
-                    hopRMNode.getLastHealthReportTime(), nextHeartbeat,
-                    isDistributedRTEnabled);
+                    hopRMNode.getLastHealthReportTime(), nextHeartbeat);
 
             ((RMNodeImpl) rmNode).setState(hopRMNode.getCurrentState());
             rmNode.recover(this);
@@ -640,8 +656,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
                         hopRMNode.getOvercommittimeout()),
                     hopRMNode.getNodemanagerVersion(),
                     hopRMNode.getHealthReport(),
-                    hopRMNode.getLastHealthReportTime(), nextHeartbeat,
-                    isDistributedRTEnabled);
+                    hopRMNode.getLastHealthReportTime(), nextHeartbeat);
             ((RMNodeImpl) rmNode).setState(hopRMNode.getCurrentState());
             rmNode.recover(this);
             alreadyRecoveredRMContextInactiveNodes.put(rmNode.getNodeID().
@@ -660,7 +675,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
         new HashMap<ContainerId, org.apache.hadoop.yarn.api.records.ContainerStatus>();
 
     public LinkedList<org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo> getUpdatedContainerInfo(
-        final String rmNodeId) {
+        final String rmNodeId, RMNodeImpl rmNode) {
       LinkedList<org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo>
           updatedContainerInfoQueue =
           new LinkedList<org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo>();
@@ -670,7 +685,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
             allUpdatedContainerInfos.get(rmNodeId);
         if (updatedContainerInfos != null) {
           List<org.apache.hadoop.yarn.api.records.ContainerStatus>
-              newlyAllocated =
+              newlyLaunched =
               new ArrayList<org.apache.hadoop.yarn.api.records.ContainerStatus>();
           List<org.apache.hadoop.yarn.api.records.ContainerStatus> completed =
               new ArrayList<org.apache.hadoop.yarn.api.records.ContainerStatus>();
@@ -710,7 +725,12 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
               if (containerStatus != null) {
                 if (containerStatus.getState().toString()
                     .equals(TablesDef.ContainerStatusTableDef.STATE_RUNNING)) {
-                  newlyAllocated.add(containerStatus);
+                  if (!rmNode.getJustLaunchedContainers().containsKey(
+                          containerStatus.getContainerId())) {
+                    LOG.debug("add newlyLaunchedContainer " + containerStatus.
+                            getContainerId());
+                    newlyLaunched.add(containerStatus);
+                  }
                 } else if (containerStatus.getState().toString()
                     .equals(TablesDef.ContainerStatusTableDef.STATE_COMPLETED)) {
                   completed.add(containerStatus);
@@ -720,7 +740,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
             org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo
                 uci =
                 new org.apache.hadoop.yarn.server.resourcemanager.rmnode.UpdatedContainerInfo(
-                    newlyAllocated, completed, updatedContainerInfoId);
+                    newlyLaunched, completed, updatedContainerInfoId);
             updatedContainerInfoQueue.add(uci);
           }
         }
@@ -874,9 +894,6 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
     dispatcher
         .register(RMStateStoreEventType.class, new ForwardingEventHandler());
     dispatcher.setDrainEventsOnStop();
-    isDistributedRTEnabled =
-        conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-            YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED);
     initInternal(conf);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStoreFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStoreFactory.java
@@ -24,8 +24,9 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 public class RMStateStoreFactory {
   
   public static RMStateStore getStore(Configuration conf) {
+    //TODO shouldn't NDBRMStateStore.class be in the config instead of here?
     RMStateStore store = ReflectionUtils.newInstance(
-        conf.getClass(YarnConfiguration.RM_STORE, MemoryRMStateStore.class,
+        conf.getClass(YarnConfiguration.RM_STORE, NDBRMStateStore.class,
             RMStateStore.class), conf);
     return store;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/QueueMetrics.java
@@ -405,7 +405,6 @@ public class QueueMetrics implements MetricsSource {
 
   public void allocateResources(String user, int containers, Resource res,
       boolean decrPending) {
-    LOG.info("allocate Resource for queue " + queueName + " parent: " + parent);
     allocatedContainers.incr(containers);
     aggregateContainersAllocated.incr(containers);
     allocatedMB.incr(res.getMemory() * containers);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
@@ -735,11 +735,11 @@ public class FifoScheduler extends AbstractYarnScheduler
   }
 
   private synchronized void nodeUpdate(RMNode rmNode,
-      TransactionState transactionState) {
-    LOG.debug("HOP :: nodeUpdate, rmNode:" + rmNode.getNodeID().toString());
+      TransactionState transactionState) {    
     org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica.FiCaSchedulerNode
         node = getNode(rmNode.getNodeID());
-
+    LOG.debug("HOP :: nodeUpdate, rmNode:" + rmNode.getNodeID().toString() + 
+            " node " + node);
     // Update resource if any change
     SchedulerUtils.updateResourceIfChanged(node, rmNode, clusterResource, LOG,
             transactionState);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/NMTokenSecretManagerInRM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/NMTokenSecretManagerInRM.java
@@ -38,7 +38,7 @@ import java.util.Iterator;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
-
+//TORECOVER TOKEN all the store action done in this class must be remplaced by transaction state actions (getStateStore)
 public class NMTokenSecretManagerInRM extends BaseNMTokenSecretManager {
 
   private static Log LOG = LogFactory.getLog(NMTokenSecretManagerInRM.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/RMContainerTokenSecretManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/RMContainerTokenSecretManager.java
@@ -43,6 +43,7 @@ import java.util.TimerTask;
  * SecretManager for ContainerTokens. This is RM-specific and rolls the
  * master-keys every so often.
  */
+//TORECOVER TOKEN all the store action done in this class must be remplaced by transaction state actions (getStateStore)
 public class RMContainerTokenSecretManager
     extends BaseContainerTokenSecretManager {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/io/hops/metadata/util/TestHopYarnAPIUtilities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/io/hops/metadata/util/TestHopYarnAPIUtilities.java
@@ -162,7 +162,7 @@ public class TestHopYarnAPIUtilities {
     Thread.sleep(1000);
     //verify that they are persisted in the db
     Map<String,FiCaSchedulerNode> dbNodes = RMUtilities.
-            getAllFiCaSchedulerNodes();
+            getAllFiCaSchedulerNodesFullTransaction();
     assertEquals(2, dbNodes.size());
 
     //submit an application of 2GB memory
@@ -199,7 +199,7 @@ public class TestHopYarnAPIUtilities {
             getAllResourceRequests();
     //retrieve requests from the database
     Map<String, List<ResourceRequest>> requests =
-        RMUtilities.getAllResourceRequests();
+        RMUtilities.getAllResourceRequestsFullTransaction();
     List<ResourceRequest> dbReqs = requests.get(attempt1.
         getAppAttemptId().toString());
 
@@ -333,7 +333,7 @@ public class TestHopYarnAPIUtilities {
 
     //test persistance of schedulerapplication
     Map<String, SchedulerApplication> schedulerApplications = RMUtilities.
-        getSchedulerApplications();
+        getSchedulerApplicationsFullTransaction();
     assertEquals("db does not contain good number of schedulerApplications", 2,
         schedulerApplications.size());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestApplicationCleanup.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestApplicationCleanup.java
@@ -142,13 +142,14 @@ public class TestApplicationCleanup {
     rm.stop();
   }
 
+  DrainDispatcher dispatcher;
   @Test
   public void testContainerCleanup() throws Exception {
 
     Logger rootLogger = LogManager.getRootLogger();
     rootLogger.setLevel(Level.DEBUG);
     rootLogger.debug("start testContainerCleanup");
-    final DrainDispatcher dispatcher = new DrainDispatcher();
+    dispatcher = new DrainDispatcher();
     MockRM rm = new MockRM() {
       @Override
       protected EventHandler<SchedulerEvent> createSchedulerEventDispatcher() {
@@ -162,6 +163,7 @@ public class TestApplicationCleanup {
 
       @Override
       protected Dispatcher createDispatcher() {
+        dispatcher = new DrainDispatcher();
         return dispatcher;
       }
     };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRM.java
@@ -613,6 +613,7 @@ public class TestRM {
     }
   }
 
+  Dispatcher dispatcher;
   /**
    * Validate killing an application when it is at accepted state.
    * <p/>
@@ -624,33 +625,34 @@ public class TestRM {
   public void testApplicationKillAtAcceptedState() throws Exception {
     LOG.debug("HOP :: current method-" + RMUtilities.getCallerMethod("TestRM"));
     YarnConfiguration conf = new YarnConfiguration();
-    final Dispatcher dispatcher = new AsyncDispatcher() {
-      @Override
-      public EventHandler getEventHandler() {
-
-        class EventArgMatcher extends ArgumentMatcher<AbstractEvent> {
-
-          @Override
-          public boolean matches(Object argument) {
-            if (argument instanceof RMAppAttemptEvent) {
-              if (((RMAppAttemptEvent) argument).getType()
-                  .equals(RMAppAttemptEventType.KILL)) {
-                return true;
-              }
-            }
-            return false;
-          }
-        }
-
-        EventHandler handler = spy(super.getEventHandler());
-        doNothing().when(handler).handle(argThat(new EventArgMatcher()));
-        return handler;
-      }
-    };
+    
 
     MockRM rm = new MockRM(conf) {
       @Override
       protected Dispatcher createDispatcher() {
+        dispatcher = new AsyncDispatcher() {
+          @Override
+          public EventHandler getEventHandler() {
+
+            class EventArgMatcher extends ArgumentMatcher<AbstractEvent> {
+
+              @Override
+              public boolean matches(Object argument) {
+                if (argument instanceof RMAppAttemptEvent) {
+                  if (((RMAppAttemptEvent) argument).getType()
+                          .equals(RMAppAttemptEventType.KILL)) {
+                    return true;
+                  }
+                }
+                return false;
+              }
+            }
+
+            EventHandler handler = spy(super.getEventHandler());
+            doNothing().when(handler).handle(argThat(new EventArgMatcher()));
+            return handler;
+          }
+        };
         return dispatcher;
       }
     };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMNodeTransitions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMNodeTransitions.java
@@ -158,7 +158,7 @@ public class TestRMNodeTransitions {
 
     NodeId nodeId = BuilderUtils.newNodeId("localhost", 0);
     node = new RMNodeImpl(nodeId, rmContext, nodeId.getHost(), 0, 0, null, null,
-        null, false);
+        null);
     nodesListManagerEvent = null;
 
   }
@@ -228,8 +228,7 @@ public class TestRMNodeTransitions {
     }
     NodeId nodeId = BuilderUtils.newNodeId("localhost:1", 1);
     RMNodeImpl node2 =
-        new RMNodeImpl(nodeId, rmContext, "test", 0, 0, null, null, null,
-            false);
+        new RMNodeImpl(nodeId, rmContext, "test", 0, 0, null, null, null);
     node2.handle(new RMNodeEvent(null, RMNodeEventType.STARTED,
         new TransactionStateImpl(TransactionType.RM)));
     //If Distributed RT is enabled, this is the only way to let the scheduler
@@ -608,7 +607,7 @@ public class TestRMNodeTransitions {
     RMNodeImpl node =
         new RMNodeImpl(nodeId, rmContext, nodeId.getHost(), 0, 0, null,
             ResourceOption.newInstance(capability,
-                RMNode.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT), null, false);
+                RMNode.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT), null);
     ((TransactionStateImpl) ts).getRMContextInfo()
         .toAddActiveRMNode(nodeId, node, 1);
     node.handle(new RMNodeEvent(node.getNodeID(), RMNodeEventType.STARTED, ts));
@@ -631,7 +630,7 @@ public class TestRMNodeTransitions {
     NodeId nodeId = BuilderUtils.newNodeId("localhost", 0);
     RMNodeImpl node =
         new RMNodeImpl(nodeId, rmContext, nodeId.getHost(), 0, 0, null, null,
-            null, false);
+            null);
     return node;
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
@@ -574,9 +574,10 @@ public class TestResourceTrackerService {
     verify(handler, never()).handle((Event) any());
   }
 
+  DrainDispatcher dispatcher;
   @Test
   public void testReconnectNode() throws Exception {
-    final DrainDispatcher dispatcher = new DrainDispatcher();
+    dispatcher = new DrainDispatcher();
     rm = new MockRM(conf) {
       @Override
       protected EventHandler<SchedulerEvent> createSchedulerEventDispatcher() {
@@ -590,6 +591,7 @@ public class TestResourceTrackerService {
 
       @Override
       protected Dispatcher createDispatcher() {
+        dispatcher = new DrainDispatcher();
         return dispatcher;
       }
     };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/applicationsmanager/TestAMRMRPCNodeUpdates.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/applicationsmanager/TestAMRMRPCNodeUpdates.java
@@ -75,6 +75,7 @@ public class TestAMRMRPCNodeUpdates {
 
       @Override
       protected Dispatcher createDispatcher() {
+        dispatcher = new DrainDispatcher();
         return dispatcher;
       }
     };

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/rmcontainer/TestRecoverRMContainerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/rmcontainer/TestRecoverRMContainerImpl.java
@@ -171,7 +171,7 @@ public class TestRecoverRMContainerImpl {
 
     // Here we are calling databse fetching part and comparing with one we have inserted
     Map<String, io.hops.metadata.yarn.entity.RMContainer> containers
-            = RMUtilities.getAllRMContainers();
+            = RMUtilities.getAllRMContainersFulTransaction();
     io.hops.metadata.yarn.entity.RMContainer recoverRmCont = containers.get(
             rmContainer.getContainerId().toString());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestDistributedRT.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestDistributedRT.java
@@ -166,7 +166,7 @@ public class TestDistributedRT {
     rm2.start();
     //Wait for leader election to start
     Thread.sleep(3000);
-    if (rm1.getRMContext().getRMGroupMembershipService().isLeader()) {
+    if (rm1.getRMContext().getGroupMembershipService().isLeader()) {
       rmL = rm1;
       rmRT = rm2;
     } else {
@@ -235,7 +235,7 @@ public class TestDistributedRT {
     MockNM nm1, nm2;
     //Wait for leader election to start
     Thread.sleep(3000);
-    if (rm1.getRMContext().getRMGroupMembershipService().isLeader()) {
+    if (rm1.getRMContext().getGroupMembershipService().isLeader()) {
       rmL = rm1;
       rmRT = rm2;
     } else {
@@ -324,7 +324,7 @@ public class TestDistributedRT {
     
     //Wait for leader election to start
     Thread.sleep(3000);
-    if (rm1.getRMContext().getRMGroupMembershipService().isLeader()) {
+    if (rm1.getRMContext().getGroupMembershipService().isLeader()) {
       rmL = rm1;
       rmRT = rm2;
     } else {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerRecovery.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestSchedulerRecovery.java
@@ -253,8 +253,7 @@ public class TestSchedulerRecovery {
         nmTokenSecretManager, null, null, conf);
     RMNodeImpl node =
         new RMNodeImpl(nodeId, rmContext, nodeId.getHost(), 0, 0, null, null,
-            null, conf.getBoolean(YarnConfiguration.HOPS_DISTRIBUTED_RT_ENABLED,
-            YarnConfiguration.DEFAULT_HOPS_DISTRIBUTED_RT_ENABLED));
+            null);
 
     RMStateStore.RMState rmState = stateStore.loadState(rmContext);
     node.recover(rmState);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestRecoverCapacityScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestRecoverCapacityScheduler.java
@@ -64,6 +64,7 @@ import org.junit.Test;
 import io.hops.metadata.yarn.entity.appmasterrpc.RPC;
 import java.util.ArrayList;
 import java.util.Collection;
+import org.apache.hadoop.yarn.server.resourcemanager.recovery.RMStateStore;
 
 public class TestRecoverCapacityScheduler {
 
@@ -94,6 +95,7 @@ public class TestRecoverCapacityScheduler {
 
     conf.setClass(YarnConfiguration.RM_SCHEDULER,
             CapacityScheduler.class, ResourceScheduler.class);
+    conf.setClass(YarnConfiguration.RM_STORE,NDBRMStateStore.class , RMStateStore.class);
   }
 
   private void setupQueueConfigurationReservation(
@@ -188,7 +190,7 @@ public class TestRecoverCapacityScheduler {
     //Check the db
     Thread.sleep(1000);
     Map<String, io.hops.metadata.yarn.entity.FiCaSchedulerNode> dbRmNodes
-            = RMUtilities.getAllFiCaSchedulerNodes();
+            = RMUtilities.getAllFiCaSchedulerNodesFullTransaction();
     assertEquals(1, dbRmNodes.size());
 
     ApplicationId appId_1 = getApplicationId(101);
@@ -327,7 +329,7 @@ public class TestRecoverCapacityScheduler {
     // App 1
     Thread.sleep(1000);
     Map<String, io.hops.metadata.yarn.entity.RMContainer> containers
-            = RMUtilities.getAllRMContainers();
+            = RMUtilities.getAllRMContainersFulTransaction();
     io.hops.metadata.yarn.entity.RMContainer rmContainer = containers.get(
             appRMContainers.get(app_1));
     assertEquals(RMContainerState.KILLED.toString(), rmContainer.getState());
@@ -370,7 +372,7 @@ public class TestRecoverCapacityScheduler {
 
     // Retrieve CSLeafQueueUserInfo from the db and make assertions
     Collection<CSLeafQueueUserInfo> leafQueueUserInfoList = RMUtilities.
-            getAllCSLeafQueueUserInfo().values();
+            getAllCSLeafQueueUserInfoFullTransaction().values();
 
     for (CSLeafQueueUserInfo leafQueueUserInfo : leafQueueUserInfoList) {
       // sri
@@ -389,7 +391,7 @@ public class TestRecoverCapacityScheduler {
     // Test CapacityScheduler node map
     List<io.hops.metadata.yarn.entity.FiCaSchedulerNode> nodeList
             = new ArrayList<io.hops.metadata.yarn.entity.FiCaSchedulerNode>(
-                    RMUtilities.getAllFiCaSchedulerNodes().values());
+                    RMUtilities.getAllFiCaSchedulerNodesFullTransaction().values());
     io.hops.metadata.yarn.entity.FiCaSchedulerNode node = nodeList.get(0);
 
     assertEquals(1, nodeList.size());
@@ -397,7 +399,7 @@ public class TestRecoverCapacityScheduler {
 
     // Test application list
     Map<String, io.hops.metadata.yarn.entity.SchedulerApplication> appMap
-            = RMUtilities.getSchedulerApplications();
+            = RMUtilities.getSchedulerApplicationsFullTransaction();
     assertEquals(2, appMap.size());
 
     for (io.hops.metadata.yarn.entity.SchedulerApplication schedulerApp

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestRecoverLeafCSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/TestRecoverLeafCSQueue.java
@@ -275,7 +275,7 @@ public class TestRecoverLeafCSQueue {
             getAbsoluteUsedCapacity(), DELTA);
 
     Collection<CSLeafQueueUserInfo> recoverCSLeafQueueUser = RMUtilities.
-            getAllCSLeafQueueUserInfo().values();
+            getAllCSLeafQueueUserInfoFullTransaction().values();
 
     for (UserInfo userInfo : a.getUsers()) {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestClientToAMTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestClientToAMTokens.java
@@ -146,7 +146,8 @@ public class TestClientToAMTokens {
     }
   }
 
-  @Test
+  DrainDispatcher dispatcher;
+  @Test(timeout = 60000)
   public void testClientToAMTokens() throws Exception {
 
     final Configuration conf = new Configuration();
@@ -162,7 +163,7 @@ public class TestClientToAMTokens {
     StartContainersResponse mockResponse = mock(StartContainersResponse.class);
     when(containerManager.startContainers((StartContainersRequest) any()))
         .thenReturn(mockResponse);
-    final DrainDispatcher dispatcher = new DrainDispatcher();
+    dispatcher = new DrainDispatcher();
 
     MockRM rm = new MockRMWithCustomAMLauncher(conf, containerManager) {
       protected ClientRMService createClientRMService() {
@@ -175,6 +176,7 @@ public class TestClientToAMTokens {
 
       @Override
       protected Dispatcher createDispatcher() {
+        dispatcher = new DrainDispatcher();
         return dispatcher;
       }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestRMDelegationTokens.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestRMDelegationTokens.java
@@ -137,7 +137,7 @@ public class TestRMDelegationTokens {
     rm1.stop();
   }
 
-  @Test(timeout = 15000)
+  @Test(timeout = 150000)
   public void testRemoveExpiredMasterKeyInRMStateStore() throws Exception {
     MemoryRMStateStore memStore = new MemoryRMStateStore();
     memStore.init(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestRMNMSecretKeys.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestRMNMSecretKeys.java
@@ -53,11 +53,12 @@ public class TestRMNMSecretKeys {
     validateRMNMKeyExchange(conf);
   }
 
+  DrainDispatcher dispatcher;
   private void validateRMNMKeyExchange(YarnConfiguration conf)
       throws Exception {
     // Default rolling and activation intervals are large enough, no need to
     // intervene
-    final DrainDispatcher dispatcher = new DrainDispatcher();
+    dispatcher = new DrainDispatcher();
     ResourceManager rm = new ResourceManager() {
 
       @Override
@@ -67,6 +68,7 @@ public class TestRMNMSecretKeys {
 
       @Override
       protected Dispatcher createDispatcher() {
+        dispatcher = new DrainDispatcher();
         return dispatcher;
       }
 


### PR DESCRIPTION
Modifications to enable automatic failover in distributed mode: …
- Use of the latest streaming library. Starting the resource tracker library when starting the resource tracker and starting the scheduler library when transitioning to active.
- Fixing the transition from active resource tracker to active scheduler instead of passive RM to active RM:
	- resource tracking services are reseted
	- when stopping the services we have to make sure that they finished handling events before to restart them.
- Fixing the recovery of the scheduler: 
	- recovering pending events.
	- recovering only the rpc that should be handled by the scheduler.
	- pulling the recovery information from the database in one unique transaction.
	- mechanism to make sure that no streamed events are missed between the starting of the recovery and the starting of the service.
- Fixing the problem of nodes changing the resource tracker to which they send heartbeats: when a resource trackers receive heartbeats from a node it doesn't know or it hasn't received heartbeat for a long time it start by recovering the node state from the database.
- change getLeastLoaded to not include the leader in the result.
- In order to get the list of active nodes in  groupMembershipProxyService we have to ask it as a super user, it may not be ideal.

Resolve #102 