### PR TITLE
fix rpc too big bug

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/NDBRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/NDBRMStateStore.java
@@ -22,6 +22,7 @@ import io.hops.metadata.yarn.entity.AppSchedulingInfo;
 import io.hops.metadata.yarn.entity.ContainerId;
 import io.hops.metadata.yarn.entity.FinishedApplications;
 import io.hops.metadata.yarn.entity.NodeHBResponse;
+import io.hops.metadata.yarn.entity.appmasterrpc.HeartBeatRPC;
 import io.hops.metadata.yarn.entity.rmstatestore.UpdatedNode;
 import io.hops.metadata.yarn.entity.rmstatestore.DelegationKey;
 import io.hops.metadata.yarn.entity.rmstatestore.DelegationToken;
@@ -336,6 +337,8 @@ public class NDBRMStateStore extends RMStateStore {
    
   private void loadRPCs(RMState rmState) throws IOException {
     rmState.appMasterRPCs = RMUtilities.getAppMasterRPCs();
+    rmState.heartBeatRPCs = RMUtilities.getHeartBeatRPCs();
+    rmState.allocateRPCs = RMUtilities.getAllocateRPCs();
   }
   
   private void loadPendingEvents(RMState rmState) throws IOException{

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
@@ -41,6 +41,8 @@ import io.hops.metadata.yarn.entity.ResourceRequest;
 import io.hops.metadata.yarn.entity.SchedulerAppReservations;
 import io.hops.metadata.yarn.entity.SchedulerApplication;
 import io.hops.metadata.yarn.entity.UpdatedContainerInfo;
+import io.hops.metadata.yarn.entity.appmasterrpc.AllocateRPC;
+import io.hops.metadata.yarn.entity.appmasterrpc.HeartBeatRPC;
 import io.hops.metadata.yarn.entity.appmasterrpc.RPC;
 import io.hops.metadata.yarn.entity.capacity.CSLeafQueueUserInfo;
 import io.hops.metadata.yarn.entity.capacity.CSQueue;
@@ -381,6 +383,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
 
     Map<KeyType, MasterKey> secretMamagerKeys;
     List<RPC> appMasterRPCs;
+    Map<Integer, HeartBeatRPC> heartBeatRPCs;
+    Map<Integer, AllocateRPC> allocateRPCs;
     List<PendingEvent> pendingEvents;
     Map<String, AppSchedulingInfo> appSchedulingInfos;
     Map<String, SchedulerApplication> schedulerApplications;
@@ -447,6 +451,14 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
       }
     }
 
+    public Map<Integer, HeartBeatRPC> getHeartBeatRPCs(){
+      return heartBeatRPCs;
+    }
+    
+    public Map<Integer, AllocateRPC> getAllocateRPCs(){
+      return allocateRPCs;
+    }
+    
     public List<PendingEvent> getPendingEvents() throws IOException {
       if (pendingEvents != null) {
         return pendingEvents;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestDistributedRTClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/TestDistributedRTClient.java
@@ -387,45 +387,6 @@ public class TestDistributedRTClient {
     LOG.info("HOP :: rmNode.uci-" + ((RMNodeImpl) rmNode).getQueue());
   }
 
-  @Ignore
-  @Test
-  public void testHeartBeatValidation()
-      throws IOException, InterruptedException {
-    RMUtilities.InitializeDB();
-    new Thread() {
-      @Override
-      public void run() {
-        for (int i = 0; i < 10000; i++) {
-          try {
-            LOG.info("HOP :: testHeartBeatValidation A - START");
-            RMUtilities.heartbeatNMRPCValidation(RPC.Type.NodeHeartbeat,
-                new byte[]{0x0}, "host:1234", null);
-            LOG.info("HOP :: testHeartBeatValidation A - FINISH");
-          } catch (IOException ex) {
-            Logger.getLogger(TestDistributedRT.class.getName()).
-                log(Level.SEVERE, null, ex);
-          }
-        }
-      }
-    }.start();
-    new Thread() {
-      @Override
-      public void run() {
-        for (int i = 0; i < 10000; i++) {
-          try {
-            LOG.info("HOP :: testHeartBeatValidation B - START");
-            RMUtilities.getRMNode("h1:1234", null, conf);
-            LOG.info("HOP :: testHeartBeatValidation B - FINISH");
-          } catch (IOException ex) {
-            Logger.getLogger(TestDistributedRT.class.getName()).
-                log(Level.SEVERE, null, ex);
-          }
-        }
-      }
-    }.start();
-
-    Thread.sleep(50000);
-  }
 
   private class RTClientWorker implements Runnable {
 


### PR DESCRIPTION
Break the Heartbeat and allocate rpcs in sub part when persisting them to the database to avoid problems of rpc too big to fit in a row of the database

fix #57