### PR TITLE
YARN-1920: TestFileSystemApplicationHistoryStore fails

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/FileSystemApplicationHistoryStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/main/java/org/apache/hadoop/yarn/server/applicationhistoryservice/FileSystemApplicationHistoryStore.java
@@ -179,7 +179,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
       LOG.info("Completed reading history information of application " + appId);
       return historyData;
     } catch (IOException e) {
-      LOG.error("Error when reading history file of application " + appId);
+      LOG.error("Error when reading history file of application " + appId, e);
       throw e;
     } finally {
       hfReader.close();
@@ -296,7 +296,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
       return historyData;
     } catch (IOException e) {
       LOG.error("Error when reading history file of application attempt" +
-          appAttemptId);
+          appAttemptId, e);
       throw e;
     } finally {
       hfReader.close();
@@ -342,7 +342,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
           "Completed reading history information of container " + containerId);
       return historyData;
     } catch (IOException e) {
-      LOG.error("Error when reading history file of container " + containerId);
+      LOG.error("Error when reading history file of container " + containerId, e);
       throw e;
     } finally {
       hfReader.close();
@@ -416,7 +416,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
             appStart.getApplicationId());
       } catch (IOException e) {
         LOG.error("Error when openning history file of application " +
-            appStart.getApplicationId());
+            appStart.getApplicationId(), e);
         throw e;
       }
       outstandingWriters.put(appStart.getApplicationId(), hfWriter);
@@ -436,7 +436,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
               " is written");
     } catch (IOException e) {
       LOG.error("Error when writing start information of application " +
-          appStart.getApplicationId());
+          appStart.getApplicationId(), e);
       throw e;
     }
   }
@@ -457,7 +457,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
               " is written");
     } catch (IOException e) {
       LOG.error("Error when writing finish information of application " +
-          appFinish.getApplicationId());
+          appFinish.getApplicationId(), e);
       throw e;
     } finally {
       hfWriter.close();
@@ -481,7 +481,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
           appAttemptStart.getApplicationAttemptId() + " is written");
     } catch (IOException e) {
       LOG.error("Error when writing start information of application attempt " +
-          appAttemptStart.getApplicationAttemptId());
+          appAttemptStart.getApplicationAttemptId(), e);
       throw e;
     }
   }
@@ -503,7 +503,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
     } catch (IOException e) {
       LOG.error(
           "Error when writing finish information of application attempt " +
-              appAttemptFinish.getApplicationAttemptId());
+              appAttemptFinish.getApplicationAttemptId(), e);
       throw e;
     }
   }
@@ -525,7 +525,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
               " is written");
     } catch (IOException e) {
       LOG.error("Error when writing start information of container " +
-          containerStart.getContainerId());
+          containerStart.getContainerId(), e);
       throw e;
     }
   }
@@ -547,7 +547,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
           containerFinish.getContainerId() + " is written");
     } catch (IOException e) {
       LOG.error("Error when writing finish information of container " +
-          containerFinish.getContainerId());
+          containerFinish.getContainerId(), e);
     }
   }
 
@@ -681,9 +681,10 @@ public class FileSystemApplicationHistoryStore extends AbstractService
 
     private TFile.Reader reader;
     private TFile.Reader.Scanner scanner;
+    FSDataInputStream fsdis;
 
     public HistoryFileReader(Path historyFile) throws IOException {
-      FSDataInputStream fsdis = fs.open(historyFile);
+    fsdis = fs.open(historyFile);
       reader = new TFile.Reader(fsdis, fs.getFileStatus(historyFile).getLen(),
           getConfig());
       reset();
@@ -711,7 +712,7 @@ public class FileSystemApplicationHistoryStore extends AbstractService
     }
 
     public void close() {
-      IOUtils.cleanup(LOG, scanner, reader);
+      IOUtils.cleanup(LOG, scanner, reader, fsdis);
     }
 
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestFileSystemApplicationHistoryStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-applicationhistoryservice/src/test/java/org/apache/hadoop/yarn/server/applicationhistoryservice/TestFileSystemApplicationHistoryStore.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.yarn.server.applicationhistoryservice;
 
 import junit.framework.Assert;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -40,6 +42,8 @@ import java.net.URI;
 
 public class TestFileSystemApplicationHistoryStore
     extends ApplicationHistoryStoreTestUtils {
+  private static Log LOG = LogFactory
+    .getLog(TestFileSystemApplicationHistoryStore.class.getName());
 
   private FileSystem fs;
   private Path fsWorkingPath;
@@ -49,7 +53,9 @@ public class TestFileSystemApplicationHistoryStore
     fs = new RawLocalFileSystem();
     Configuration conf = new Configuration();
     fs.initialize(new URI("/"), conf);
-    fsWorkingPath = new Path("Test");
+    fsWorkingPath =
+        new Path("target",
+          TestFileSystemApplicationHistoryStore.class.getSimpleName());
     fs.delete(fsWorkingPath, true);
     conf.set(YarnConfiguration.FS_APPLICATION_HISTORY_STORE_URI,
         fsWorkingPath.toString());
@@ -67,6 +73,7 @@ public class TestFileSystemApplicationHistoryStore
 
   @Test
   public void testReadWriteHistoryData() throws IOException {
+    LOG.info("Starting testReadWriteHistoryData");
     testWriteHistoryData(5);
     testReadHistoryData(5);
   }
@@ -165,6 +172,7 @@ public class TestFileSystemApplicationHistoryStore
 
   @Test
   public void testWriteAfterApplicationFinish() throws IOException {
+    LOG.info("Starting testWriteAfterApplicationFinish");
     ApplicationId appId = ApplicationId.newInstance(0, 1);
     writeApplicationStartData(appId);
     writeApplicationFinishData(appId);
@@ -201,6 +209,7 @@ public class TestFileSystemApplicationHistoryStore
 
   @Test
   public void testMassiveWriteContainerHistoryData() throws IOException {
+    LOG.info("Starting testMassiveWriteContainerHistoryData");
     long mb = 1024 * 1024;
     long usedDiskBefore = fs.getContentSummary(fsWorkingPath).getLength() / mb;
     ApplicationId appId = ApplicationId.newInstance(0, 1);
@@ -219,12 +228,14 @@ public class TestFileSystemApplicationHistoryStore
 
   @Test
   public void testMissingContainerHistoryData() throws IOException {
+    LOG.info("Starting testMissingContainerHistoryData");
     testWriteHistoryData(3, true, false);
     testReadHistoryData(3, true, false);
   }
   
   @Test
   public void testMissingApplicationAttemptHistoryData() throws IOException {
+    LOG.info("Starting testMissingApplicationAttemptHistoryData");
     testWriteHistoryData(3, false, true);
     testReadHistoryData(3, false, true);
   }


### PR DESCRIPTION
the test fails because we are leaking a file-handle in the history service

https://issues.apache.org/jira/browse/YARN-1920