### PR TITLE
correct capacity scheduler recovery

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/FiCaSchedulerAppInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/FiCaSchedulerAppInfo.java
@@ -59,6 +59,7 @@ public class FiCaSchedulerAppInfo {
   private AppSchedulingInfo fiCaSchedulerAppToAdd;
   private Map<Integer, Resource> resourcesToUpdate
           = new HashMap<Integer, Resource>();
+  private boolean create = false;
   
   protected ApplicationAttemptId applicationAttemptId;
   private Map<ContainerId, ToPersistContainersInfo> liveContainersToAdd
@@ -120,10 +121,12 @@ public class FiCaSchedulerAppInfo {
     this.applicationAttemptId = applicationAttemptId;
   }
 
-  public FiCaSchedulerAppInfo(SchedulerApplicationAttempt schedulerApp,
-          TransactionStateImpl transactionState) {
-    this.transactionState = transactionState;
-    this.applicationAttemptId = schedulerApp.getApplicationAttemptId();
+  public void createFull(SchedulerApplicationAttempt schedulerApp){
+    this.create = true;
+    updateFull(schedulerApp);
+  }
+  
+  public void updateFull(SchedulerApplicationAttempt schedulerApp) {
     fiCaSchedulerAppToAdd = new AppSchedulingInfo(applicationAttemptId.
             toString(),
             applicationAttemptId.getApplicationId().toString(),
@@ -468,7 +471,7 @@ public class FiCaSchedulerAppInfo {
   }
 
   public void remove(SchedulerApplicationAttempt schedulerApp) {
-    if (fiCaSchedulerAppToAdd == null) {
+    if (fiCaSchedulerAppToAdd == null || !create) {
       remove = true;
       fiCaSchedulerAppToAdd = new AppSchedulingInfo(applicationAttemptId.
               toString());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/SchedulerApplicationInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/ha/common/SchedulerApplicationInfo.java
@@ -160,19 +160,5 @@ public class SchedulerApplicationInfo {
     agregatedAppInfo.persist();
     }
   }
-
-  public void setFiCaSchedulerAppInfo(
-      SchedulerApplicationAttempt schedulerApp) {
-    
-    ApplicationId appId = schedulerApp.getApplicationId();
-    FiCaSchedulerAppInfo ficaInfo = new FiCaSchedulerAppInfo(schedulerApp, transactionState);
-    fiCaSchedulerAppInfoLock.lock();
-    if(fiCaSchedulerAppInfo.get(appId.toString())==null){
-      fiCaSchedulerAppInfo.put(appId.toString(), new HashMap<String, FiCaSchedulerAppInfo>());
-    }
-    fiCaSchedulerAppInfo.get(appId.toString())
-        .put(schedulerApp.getApplicationAttemptId().toString(), ficaInfo);
-    fiCaSchedulerAppInfoLock.unlock();
-  }
-
+  
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMUtilities.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/io/hops/metadata/util/RMUtilities.java
@@ -50,6 +50,7 @@ import io.hops.metadata.yarn.dal.ResourceRequestDataAccess;
 import io.hops.metadata.yarn.dal.SchedulerApplicationDataAccess;
 import io.hops.metadata.yarn.dal.UpdatedContainerInfoDataAccess;
 import io.hops.metadata.yarn.dal.capacity.CSLeafQueueUserInfoDataAccess;
+import io.hops.metadata.yarn.dal.capacity.CSLeafQueuesPendingAppsDataAccess;
 import io.hops.metadata.yarn.dal.capacity.CSQueueDataAccess;
 import io.hops.metadata.yarn.dal.capacity.FiCaSchedulerAppReservedContainersDataAccess;
 import io.hops.metadata.yarn.dal.fair.AppSchedulableDataAccess;
@@ -644,6 +645,14 @@ public static Map<String, List<ResourceRequest>> getAllResourceRequestsFullTrans
         .handle();
   }
 
+  public static Map<String, Set<String>> getCSLeafQueuesPendingApps()
+          throws IOException {
+    CSLeafQueuesPendingAppsDataAccess DA
+            = (CSLeafQueuesPendingAppsDataAccess) YarnAPIStorageFactory
+            .getDataAccess(CSLeafQueuesPendingAppsDataAccess.class);
+    return DA.getAll();
+  }
+  
   public static Map<String, List<AppSchedulingInfoBlacklist>> getAllBlackLists()
           throws IOException {
     AppSchedulingInfoBlacklistDataAccess DA

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ApplicationMasterService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ApplicationMasterService.java
@@ -734,7 +734,8 @@ public class ApplicationMasterService extends AbstractService
               getAllocatedContainers()) {
         NMToken nmToken = rmContext.getNMTokenSecretManager()
                 .createAndGetNMToken(state.getAppSchedulingInfo(
-                                attemptId.getApplicationId().toString()).
+                                attemptId.getApplicationId().toString()).get(
+                                attemptId.toString()).
                         getUser(),
                         attemptId,
                         container);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/NDBRMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/NDBRMStateStore.java
@@ -380,9 +380,12 @@ public class NDBRMStateStore extends RMStateStore {
   private void loadAppSchedulingInfos(RMState rmState) throws IOException {
     List<AppSchedulingInfo> appSchedulingInfosList =
         RMUtilities.getAppSchedulingInfos();
-    rmState.appSchedulingInfos = new HashMap<String, AppSchedulingInfo>();
+    rmState.appSchedulingInfos = new HashMap<String, Map<String,AppSchedulingInfo>>();
     for (AppSchedulingInfo info : appSchedulingInfosList) {
-      rmState.appSchedulingInfos.put(info.getAppId(), info);
+      if(rmState.appSchedulingInfos.get(info.getAppId())==null){
+        rmState.appSchedulingInfos.put(info.getAppId(), new HashMap<String, AppSchedulingInfo>());
+      }
+      rmState.appSchedulingInfos.get(info.getAppId()).put(info.getSchedulerAppId(), info);
     }
   }
   
@@ -424,6 +427,10 @@ public class NDBRMStateStore extends RMStateStore {
   
   private void loadAllQueueMetrics(RMState rmState) throws IOException {
     rmState.allQueueMetrics = RMUtilities.getAllQueueMetrics();
+  }
+  
+  private void loadCSLeafQueuesPendingApps(RMState rmState) throws IOException{
+    rmState.csLeafQueuesPendingApps = RMUtilities.getCSLeafQueuesPendingApps();
   }
   
   private void loadNodeHeartBeatResponses(RMState rmState) throws IOException {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/RMStateStore.java
@@ -386,7 +386,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
     Map<Integer, HeartBeatRPC> heartBeatRPCs;
     Map<Integer, AllocateRPC> allocateRPCs;
     List<PendingEvent> pendingEvents;
-    Map<String, AppSchedulingInfo> appSchedulingInfos;
+    Map<String, Map<String, AppSchedulingInfo>> appSchedulingInfos;
     Map<String, SchedulerApplication> schedulerApplications;
     Map<String, FiCaSchedulerNode> fiCaSchedulerNodes;
     Map<String, List<LaunchedContainers>> launchedContainers;
@@ -401,6 +401,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
     Map<String, Set<ContainerId>> containersToClean;
     Map<String, List<ApplicationId>> finishedApplications;
     Map<String, Map<Integer, Map<Integer, Resource>>> nodesResources;
+    Map<String, Set<String>> csLeafQueuesPendingApps;
     Map<String, Container> allContainers;
     Map<String, RMContainer> allRMContainers;
     List<RMContextActiveNodes> allRMContextActiveNodes;
@@ -467,8 +468,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
       }
     }
     
-    public AppSchedulingInfo getAppSchedulingInfo(final String appId)
-        throws IOException {
+    public Map<String, AppSchedulingInfo> getAppSchedulingInfo(
+            final String appId)
+            throws IOException {
       return appSchedulingInfos.get(appId);
     }
 
@@ -881,6 +883,14 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerStat
           nodesResources.get(id).get(type) != null) {
         return nodesResources.get(id).get(type).get(parent);
       } else {
+        return null;
+      }
+    }
+    
+    public Set<String> getCSLeafQueuePendingApps(String path){
+      if(csLeafQueuesPendingApps!=null){
+        return csLeafQueuesPendingApps.get(path);
+      }else{
         return null;
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplication.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplication.java
@@ -64,8 +64,9 @@ public class SchedulerApplication {
     this.currentAttempt = currentAttempt;
     if (ts != null) {
       ((TransactionStateImpl) ts).getSchedulerApplicationInfos(
-              this.currentAttempt.appSchedulingInfo.applicationId)
-          .setFiCaSchedulerAppInfo(currentAttempt);
+              this.currentAttempt.appSchedulingInfo.applicationId).
+              getFiCaSchedulerAppInfo(currentAttempt.getApplicationAttemptId()).
+              createFull(currentAttempt);
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerApplicationAttempt.java
@@ -300,7 +300,8 @@ public class SchedulerApplicationAttempt implements Recoverable{
       resetReReservations(priority, transactionState);
     } else {
       ((TransactionStateImpl) transactionState).getSchedulerApplicationInfos(
-              this.appSchedulingInfo.applicationId).setFiCaSchedulerAppInfo(this);
+              this.appSchedulingInfo.applicationId).getFiCaSchedulerAppInfo(this.getApplicationAttemptId()).updateFull(this);
+              
       // Note down the re-reservation
       addReReservation(priority, transactionState);
     }
@@ -418,8 +419,10 @@ public class SchedulerApplicationAttempt implements Recoverable{
 
   public void recover(RMStateStore.RMState state) throws IOException{
     io.hops.metadata.yarn.entity.AppSchedulingInfo hopInfo =
-            state.getAppSchedulingInfo(
-                    appSchedulingInfo.applicationId.toString());
+            state.
+            getAppSchedulingInfo(
+                    appSchedulingInfo.applicationId.toString()).get(this.
+                    getApplicationAttemptId().toString());
     this.appSchedulingInfo.recover(hopInfo, state);
     ApplicationAttemptId applicationAttemptId =
         this.appSchedulingInfo.getApplicationAttemptId();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/fifo/FifoScheduler.java
@@ -1029,30 +1029,32 @@ public class FifoScheduler extends AbstractYarnScheduler
         ApplicationId appId = ConverterUtils.toApplicationId(fsapp.getAppid());
 
         //retrieve HopSchedulerApplication
-        SchedulerApplication hopSchedulerApplication =
-            state.getSchedulerApplication(fsapp.getAppid());
+        SchedulerApplication hopSchedulerApplication = state.
+                getSchedulerApplication(fsapp.getAppid());
         //construct SchedulerAppliaction
-        org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplication
-            app =
-            new org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplication(
-                DEFAULT_QUEUE, hopSchedulerApplication.getUser());
+        org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplication app
+                = new org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplication(
+                        DEFAULT_QUEUE, hopSchedulerApplication.getUser());
 
         //retrieve HopApplicationAttemptId for this specific appId
-        AppSchedulingInfo hopFiCaSchedulerApp =
-            state.getAppSchedulingInfo(fsapp.getAppid());
-        if (hopFiCaSchedulerApp != null) {
-          //construct ApplicationAttemptId
-          ApplicationAttemptId appAttemptId = ConverterUtils
-              .toApplicationAttemptId(hopFiCaSchedulerApp.getSchedulerAppId());
-
-
-          FiCaSchedulerApp appAttempt =
-            new FiCaSchedulerApp(appAttemptId,
-                  hopFiCaSchedulerApp.getUser(),
-                  DEFAULT_QUEUE, activeUsersManager, this.rmContext,
-                  maxAllocatedContainersPerRequest);
-          appAttempt.recover(state);
-          app.setCurrentAppAttempt(appAttempt, null);
+        for (AppSchedulingInfo hopFiCaSchedulerApp : state.getAppSchedulingInfo(
+                fsapp.getAppid()).values()) {
+          if (hopFiCaSchedulerApp != null) {
+            //construct ApplicationAttemptId
+            ApplicationAttemptId appAttemptId = ConverterUtils
+                    .toApplicationAttemptId(hopFiCaSchedulerApp.
+                            getSchedulerAppId());
+            if (app.getCurrentAppAttempt() == null
+                    || app.getCurrentAppAttempt().getApplicationAttemptId().
+                    compareTo(appAttemptId) < 0) {
+              FiCaSchedulerApp appAttempt = new FiCaSchedulerApp(appAttemptId,
+                      hopFiCaSchedulerApp.getUser(),
+                      DEFAULT_QUEUE, activeUsersManager, this.rmContext,
+                      maxAllocatedContainersPerRequest);
+              appAttempt.recover(state);
+              app.setCurrentAppAttempt(appAttempt, null);
+            }
+          }
         }
         applications.put(appId, app);
 


### PR DESCRIPTION
Correct error that made that only one appAttempt was recovered per app
Correct error that made that FicaSchedulerAppInfo was not removed from the database if it add been updated in the same transaction
When recovering leafQueue the recover function was unsing appAttempt.isPending to decide to put the application in the pending queue or in the active queue but appAttempt.isPending and the leafQueue pending queue are not linked, introducing a new mechanism to persist the pending queue in the database