### PR TITLE
Yarn 614

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMAppImpl.java
@@ -637,9 +637,10 @@ public class RMAppImpl implements RMApp, Recoverable {
         new RMAppAttemptImpl(appAttemptId, rmContext, scheduler, masterService,
           submissionContext, conf,
           // The newly created attempt maybe last attempt if (number of
-          // previously NonPreempted attempts + 1) equal to the max-attempt
+          // previously failed attempts(which should not include Preempted,
+          // hardware error and NM resync) + 1) equal to the max-attempt
           // limit.
-          maxAppAttempts == (getNumNonPreemptedAppAttempts() + 1));
++          maxAppAttempts == (getNumFailedAppAttempts() + 1));
 
     attempts.put(appAttemptId, attempt);
     if (ts != null) {
@@ -752,7 +753,7 @@ public class RMAppImpl implements RMApp, Recoverable {
       msg = "Unmanaged application " + this.getApplicationId() +
           " failed due to " + failedEvent.getDiagnostics() +
           ". Failing the application.";
-    } else if (getNumNonPreemptedAppAttempts() >= this.maxAppAttempts) {
+    } else if (getNumFailedAppAttempts() >= this.maxAppAttempts) {
       msg = "Application " + this.getApplicationId() + " failed " +
           this.maxAppAttempts + " times due to " +
           failedEvent.getDiagnostics() + ". Failing the application.";
@@ -899,11 +900,12 @@ public class RMAppImpl implements RMApp, Recoverable {
 
   }
   
-  private int getNumNonPreemptedAppAttempts() {
+  private int getNumFailedAppAttempts() {
     int completedAttempts = 0;
-    // Do not count AM preemption as attempt failure.
+    // Do not count AM preemption, hardware failures or NM resync
+    // as attempt failure.
     for (RMAppAttempt attempt : attempts.values()) {
-      if (!attempt.isPreempted()) {
+      if (attempt.shouldCountTowardsMaxAttemptRetry()) {
         completedAttempts++;
       }
     }
@@ -924,7 +926,7 @@ public class RMAppImpl implements RMApp, Recoverable {
     @Override
     public RMAppState transition(RMAppImpl app, RMAppEvent event) {
       if (!app.submissionContext.getUnmanagedAM() &&
-          app.getNumNonPreemptedAppAttempts() < app.maxAppAttempts) {
+           app.getNumFailedAppAttempts() < app.maxAppAttempts) {
         boolean transferStateFromPreviousAttempt;
         RMAppFailedAttemptEvent failedEvent = (RMAppFailedAttemptEvent) event;
         transferStateFromPreviousAttempt =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttempt.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/attempt/RMAppAttempt.java
@@ -245,12 +245,18 @@ public interface RMAppAttempt extends EventHandler<RMAppAttemptEvent> {
    */
   ApplicationAttemptReport createApplicationAttemptReport();
 
-  /**
-   * Return the flag which indicates whether the attempt is preempted by the
-   * scheduler.
+  /*
+   * Return the flag which indicates whether the attempt failure should be
+   * counted to attempt retry count.
+   * <ul>
+   * There failure types should not be counted to attempt retry count:
+   * <li>preempted by the scheduler.</li>
+   * <li>hardware failures, such as NM failing, lost NM and NM disk errors.</li>
+   * <li>killed by RM because of RM restart or failover.</li>
+   * </ul>
    */
-  boolean isPreempted();
-  
+  boolean shouldCountTowardsMaxAttemptRetry();  
+
   public int getAMContainerExitStatus();
 
   public Credentials getCredentials();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/applicationsmanager/TestAMRestart.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/applicationsmanager/TestAMRestart.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -53,10 +54,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplicat
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.yarn.server.resourcemanager.recovery.NDBRMStateStore;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
+import org.apache.hadoop.yarn.util.Records;
 
 /**
  * Test to restart the AM on failure.
@@ -388,15 +392,23 @@ public class TestAMRestart {
     }    
   }
   
-  // AM container preempted should not be counted towards AM max retry count.
-  @Test(timeout = 80000)
-  public void testAMPreemptedNotCountedForAMFailures() throws Exception {
+  // AM container preempted, nm disk failure
+  // should not be counted towards AM max retry count.
+  @Test(timeout = 100000)
+  public void testShouldNotCountFailureToMaxAttemptRetry() throws Exception {
     YarnConfiguration conf = new YarnConfiguration();
     conf.setClass(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class,
       ResourceScheduler.class);
     // explicitly set max-am-retry count as 1.
     conf.setInt(YarnConfiguration.RM_AM_MAX_ATTEMPTS, 1);
-    MockRM rm1 = new MockRM(conf);
+    conf.setBoolean(YarnConfiguration.RECOVERY_ENABLED, true);
+    conf.set(YarnConfiguration.RM_STORE, NDBRMStateStore.class.getName());
+    YarnAPIStorageFactory.setConfiguration(conf);
+    RMStorageFactory.setConfiguration(conf);
+    RMUtilities.InitializeDB();
+    NDBRMStateStore stateStore = new NDBRMStateStore();
+    stateStore.init(conf);
+    MockRM rm1 = new MockRM(conf, stateStore);
     rm1.start();
     MockNM nm1 =
         new MockNM("127.0.0.1:1234", 8000, rm1.getResourceTrackerService());
@@ -409,11 +421,15 @@ public class TestAMRestart {
     ContainerId amContainer =
         ContainerId.newInstance(am1.getApplicationAttemptId(), 1);
     // Preempt the first attempt;
-    scheduler.killContainer(scheduler.getRMContainer(amContainer), new TransactionStateImpl( TransactionState.TransactionType.APP)); // TODO: check TransactionState
+    TransactionState ts = rm1.getRMContext().getTransactionStateManager().getCurrentTransactionStatePriority(-1,"test" );
+    scheduler.killContainer(scheduler.getRMContainer(amContainer), ts); // TODO: check TransactionState
+    ts.decCounter(TransactionState.TransactionType.INIT);
 
     am1.waitForState(RMAppAttemptState.FAILED);
-    Assert.assertTrue(attempt1.isPreempted());
+    Assert.assertTrue(! attempt1.shouldCountTowardsMaxAttemptRetry());
     rm1.waitForState(app1.getApplicationId(), RMAppState.ACCEPTED);
+////    ApplicationState appState =
+////        stateStore.loadState(rm1.getRMContext()).getApplicationState().get(app1.getApplicationId());
     // AM should be restarted even though max-am-attempt is 1.
     MockAM am2 = MockRM.launchAndRegisterAM(app1, rm1, nm1);
     RMAppAttempt attempt2 = app1.getCurrentAppAttempt();
@@ -422,23 +438,76 @@ public class TestAMRestart {
     // Preempt the second attempt.
     ContainerId amContainer2 =
         ContainerId.newInstance(am2.getApplicationAttemptId(), 1);
-    scheduler.killContainer(scheduler.getRMContainer(amContainer2), new TransactionStateImpl( TransactionState.TransactionType.APP));  // TODO: check TransactionState
-
+    ts = rm1.getRMContext().getTransactionStateManager().getCurrentTransactionStatePriority(-1,"test" );
+    scheduler.killContainer(scheduler.getRMContainer(amContainer2), ts);  // TODO: check TransactionState
+    ts.decCounter(TransactionState.TransactionType.INIT);
+    
     am2.waitForState(RMAppAttemptState.FAILED);
-    Assert.assertTrue(attempt2.isPreempted());
+    Assert.assertTrue(! attempt2.shouldCountTowardsMaxAttemptRetry());
     rm1.waitForState(app1.getApplicationId(), RMAppState.ACCEPTED);
     MockAM am3 = MockRM.launchAndRegisterAM(app1, rm1, nm1);
     RMAppAttempt attempt3 = app1.getCurrentAppAttempt();
     Assert.assertTrue(((RMAppAttemptImpl) attempt3).mayBeLastAttempt());
 
-    // fail the AM normally
-    nm1.nodeHeartbeat(am3.getApplicationAttemptId(), 1, ContainerState.COMPLETE);
+    // mimic NM disk_failure
+    ContainerStatus containerStatus = Records.newRecord(ContainerStatus.class);
+    containerStatus.setContainerId(attempt3.getMasterContainer().getId());
+    containerStatus.setDiagnostics("mimic NM disk_failure");
+    containerStatus.setState(ContainerState.COMPLETE);
+    containerStatus.setExitStatus(ContainerExitStatus.DISKS_FAILED);
+    Map<ApplicationId, List<ContainerStatus>> conts =
+        new HashMap<ApplicationId, List<ContainerStatus>>();
+    conts.put(app1.getApplicationId(),
+      Collections.singletonList(containerStatus));
+    nm1.nodeHeartbeat(conts, true);
+
     am3.waitForState(RMAppAttemptState.FAILED);
-    Assert.assertFalse(attempt3.isPreempted());
+    
+    Assert.assertTrue(! attempt3.shouldCountTowardsMaxAttemptRetry());
+    stateStore = new NDBRMStateStore();     // TODO: NDBRMStateStore assumes that we load state only once. This is why we had to create a new object in order to load new state
+    stateStore.init(conf);
+    ApplicationState appState =
+        stateStore.loadState(rm1.getRMContext()).getApplicationState().get(app1.getApplicationId());
+    Assert.assertEquals(ContainerExitStatus.DISKS_FAILED,
+      appState.getAttempt(am3.getApplicationAttemptId())
+        .getAMContainerExitStatus());
+
+    rm1.waitForState(app1.getApplicationId(), RMAppState.ACCEPTED);
+    MockAM am4 = MockRM.launchAndRegisterAM(app1, rm1, nm1);
+    RMAppAttempt attempt4 = app1.getCurrentAppAttempt();
+    Assert.assertTrue(((RMAppAttemptImpl) attempt4).mayBeLastAttempt());
+
+    // create second NM, and register to rm1
+    MockNM nm2 =
+        new MockNM("127.0.0.1:2234", 8000, rm1.getResourceTrackerService());
+    nm2.registerNode();
+    // nm1 heartbeats to report unhealthy
+    // This will mimic ContainerExitStatus.ABORT
+    nm1.nodeHeartbeat(false);
+    am4.waitForState(RMAppAttemptState.FAILED);
+    stateStore = new NDBRMStateStore();     // TODO: NDBRMStateStore assumes that we load state only once. This is why we had to create a new object in order to load new state
+    stateStore.init(conf);
+    appState =
+        stateStore.loadState(rm1.getRMContext()).getApplicationState().get(app1.getApplicationId());
+    Assert.assertTrue(! attempt4.shouldCountTowardsMaxAttemptRetry());
+    Assert.assertEquals(ContainerExitStatus.ABORTED,
+      appState.getAttempt(am4.getApplicationAttemptId())
+        .getAMContainerExitStatus());
+    // launch next AM in nm2
+    nm2.nodeHeartbeat(true);
+    MockAM am5 =
+        rm1.waitForNewAMToLaunchAndRegister(app1.getApplicationId(), 5, nm2);
+    RMAppAttempt attempt5 = app1.getCurrentAppAttempt();
+    Assert.assertTrue(((RMAppAttemptImpl) attempt5).mayBeLastAttempt());
+    // fail the AM normally
+    nm2
+      .nodeHeartbeat(am5.getApplicationAttemptId(), 1, ContainerState.COMPLETE);
+    am5.waitForState(RMAppAttemptState.FAILED);
+    Assert.assertTrue(attempt5.shouldCountTowardsMaxAttemptRetry());
 
     // AM should not be restarted.
     rm1.waitForState(app1.getApplicationId(), RMAppState.FAILED);
-    Assert.assertEquals(3, app1.getAppAttempts().size());
+    Assert.assertEquals(5, app1.getAppAttempts().size());
     rm1.stop();
   }
 
@@ -479,7 +548,7 @@ public class TestAMRestart {
     ts.decCounter(TransactionState.TransactionType.INIT);
 
     am1.waitForState(RMAppAttemptState.FAILED);
-    Assert.assertTrue(attempt1.isPreempted());
+    Assert.assertTrue(! attempt1.shouldCountTowardsMaxAttemptRetry());
     rm1.waitForState(app1.getApplicationId(), RMAppState.ACCEPTED);
     Thread.sleep(500);
     // state store has 1 attempt stored.
@@ -506,11 +575,77 @@ public class TestAMRestart {
 //    RMAppAttempt attempt2 =
 //        rm2.getRMContext().getRMApps().get(app1.getApplicationId())
 //          .getCurrentAppAttempt();
-//    Assert.assertFalse(attempt2.isPreempted());
+//    Assert.assertFalse(attempt2.shouldCountTowardsMaxAttemptRetry());
 //    Assert.assertEquals(ContainerExitStatus.INVALID,
 //      appState.getAttempt(am2.getApplicationAttemptId())
 //        .getAMContainerExitStatus());
     rm1.stop();
 //    rm2.stop();
   }
+  
+// TODO: Reimplement the test in HOPS style of recovery
+//  // Test regular RM restart/failover, new RM should not count
+//  // AM failure towards the max-retry-account and should be able to
+//  // re-launch the AM.
+//  @Test(timeout = 100000)
+//  public void testRMRestartOrFailoverNotCountedForAMFailures()
+//      throws Exception {
+//    YarnConfiguration conf = new YarnConfiguration();
+//    conf.setClass(YarnConfiguration.RM_SCHEDULER, CapacityScheduler.class,
+//      ResourceScheduler.class);
+//    conf.setBoolean(YarnConfiguration.RECOVERY_ENABLED, true);
+//    conf.set(YarnConfiguration.RM_STORE, NDBRMStateStore.class.getName());
+//    // explicitly set max-am-retry count as 1.
+//    conf.setInt(YarnConfiguration.RM_AM_MAX_ATTEMPTS, 1);
+//    YarnAPIStorageFactory.setConfiguration(conf);
+//    RMStorageFactory.setConfiguration(conf);
+//    RMUtilities.InitializeDB();
+//    NDBRMStateStore stateStore = new NDBRMStateStore();
+//    stateStore.init(conf);
+//
+//    MockRM rm1 = new MockRM(conf, stateStore);
+//    rm1.start();
+//    MockNM nm1 =
+//        new MockNM("127.0.0.1:1234", 8000, rm1.getResourceTrackerService());
+//    nm1.registerNode();
+//    RMApp app1 = rm1.submitApp(200);
+//    // AM should be restarted even though max-am-attempt is 1.
+//    MockAM am1 = MockRM.launchAndRegisterAM(app1, rm1, nm1);
+//    RMAppAttempt attempt1 = app1.getCurrentAppAttempt();
+//    Assert.assertTrue(((RMAppAttemptImpl) attempt1).mayBeLastAttempt());
+//
+//    // Restart rm.
+//    MockRM rm2 = new MockRM(conf, stateStore);
+//    rm2.start();
+//    ApplicationState appState =
+//        stateStore.loadState(rm1.getRMContext()).getApplicationState().get(app1.getApplicationId());
+//    // re-register the NM
+//    nm1.setResourceTrackerService(rm2.getResourceTrackerService());
+//    NMContainerStatus status = Records.newRecord(NMContainerStatus.class);
+//    status
+//      .setContainerExitStatus(ContainerExitStatus.KILLED_BY_RESOURCEMANAGER);
+//    status.setContainerId(attempt1.getMasterContainer().getId());
+//    status.setContainerState(ContainerState.COMPLETE);
+//    status.setDiagnostics("");
+//    nm1.registerNode(Collections.singletonList(status), null);
+//    rm2.waitForState(attempt1.getAppAttemptId(), RMAppAttemptState.FAILED);
+//    Assert.assertEquals(ContainerExitStatus.KILLED_BY_RESOURCEMANAGER,
+//      appState.getAttempt(am1.getApplicationAttemptId())
+//        .getAMContainerExitStatus());
+//    // Will automatically start a new AppAttempt in rm2
+//    rm2.waitForState(app1.getApplicationId(), RMAppState.ACCEPTED);
+//    MockAM am2 =
+//        rm2.waitForNewAMToLaunchAndRegister(app1.getApplicationId(), 2, nm1);
+//    MockRM.finishAMAndVerifyAppState(app1, rm2, nm1, am2);
+//    RMAppAttempt attempt3 =
+//        rm2.getRMContext().getRMApps().get(app1.getApplicationId())
+//          .getCurrentAppAttempt();
+//    Assert.assertTrue(attempt3.shouldCountTowardsMaxAttemptRetry());
+//    Assert.assertEquals(ContainerExitStatus.INVALID,
+//      appState.getAttempt(am2.getApplicationAttemptId())
+//        .getAMContainerExitStatus());
+//
+//    rm1.stop();
+//    rm2.stop();
+//  }
 }


### PR DESCRIPTION
YARN-614
Separate AM failures from hardware failure or YARN error and do not count them to AM retry count
https://issues.apache.org/jira/browse/YARN-614

Used NDBRMStateStore instead of the MemoryRMStateStore in TestAMRestart.java

TODO in TestAMRestart:
- NDBRMStateStore assumes that we load state only once. This is why we had to create a new object in order to load new state
- Reimplement testRMRestartOrFailoverNotCountedForAMFailures() in HOPS recovery stile