### PR TITLE
Yarn formating

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/HdfsStorageFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/HdfsStorageFactory.java
@@ -330,9 +330,9 @@ public class HdfsStorageFactory {
     return dStorageFactory.getDataAccess(type);
   }
   
-  public static boolean formatAllStorage() throws StorageException {
+  public static boolean formatStorage() throws StorageException {
     Cache.getInstance().flush();
-    return dStorageFactory.getConnector().formatAllStorage();
+    return dStorageFactory.getConnector().formatStorage();
   }
   
   public static boolean formatAllStorageNonTransactional()

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/HdfsStorageFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/HdfsStorageFactory.java
@@ -330,15 +330,15 @@ public class HdfsStorageFactory {
     return dStorageFactory.getDataAccess(type);
   }
   
-  public static boolean formatStorage() throws StorageException {
+  public static boolean formatAllStorage() throws StorageException {
     Cache.getInstance().flush();
-    return dStorageFactory.getConnector().formatStorage();
+    return dStorageFactory.getConnector().formatAllStorage();
   }
   
-  public static boolean formatStorageNonTransactional()
+  public static boolean formatAllStorageNonTransactional()
       throws StorageException {
     Cache.getInstance().flush();
-    return dStorageFactory.getConnector().formatStorageNonTransactional();
+    return dStorageFactory.getConnector().formatAllStorageNonTransactional();
   }
 
   public static boolean formatStorage(Class<? extends EntityDataAccess>... das)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -749,7 +749,7 @@ public class NameNode {
       if (force) {
         HdfsStorageFactory.formatAllStorageNonTransactional();
       } else {
-        HdfsStorageFactory.formatAllStorage();
+        HdfsStorageFactory.formatStorage();
       }
       StorageInfo
           .storeStorageInfoToDB(clusterId);  //this adds new row to the db

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -747,9 +747,9 @@ public class NameNode {
     try {
       HdfsStorageFactory.setConfiguration(conf);
       if (force) {
-        HdfsStorageFactory.formatStorageNonTransactional();
+        HdfsStorageFactory.formatAllStorageNonTransactional();
       } else {
-        HdfsStorageFactory.formatStorage();
+        HdfsStorageFactory.formatAllStorage();
       }
       StorageInfo
           .storeStorageInfoToDB(clusterId);  //this adds new row to the db

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/io/hops/metadata/util/YarnAPIStorageFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/io/hops/metadata/util/YarnAPIStorageFactory.java
@@ -18,6 +18,7 @@ package io.hops.metadata.util;
 import io.hops.DalDriver;
 import io.hops.DalStorageFactory;
 import io.hops.StorageConnector;
+import io.hops.exception.StorageException;
 import io.hops.exception.StorageInitializtionException;
 import io.hops.metadata.adaptor.YarnVariablesDALAdaptor;
 import io.hops.metadata.common.EntityDataAccess;
@@ -161,5 +162,14 @@ public class YarnAPIStorageFactory {
       return dataAccessAdaptors.get(type);
     }
     return dStorageFactory.getDataAccess(type);
+  }
+  
+  public static boolean formatYarnStorageNonTransactional()
+      throws StorageException {
+    return dStorageFactory.getConnector().formatYarnStorageNonTransactional();
+  }
+  
+  public static boolean formatYarnStorage() throws StorageException {
+    return dStorageFactory.getConnector().formatYarnStorage();
   }
 }

--- a/hops-leader-election/src/main/java/io/hops/metadata/LEStorageFactory.java
+++ b/hops-leader-election/src/main/java/io/hops/metadata/LEStorageFactory.java
@@ -160,9 +160,9 @@ public class LEStorageFactory {
     return dStorageFactory.getConnector().formatStorage();
   }
   
-  public static boolean formatStorageNonTransactional()
+  public static boolean formatAllStorageNonTransactional()
       throws StorageException {
-    return dStorageFactory.getConnector().formatStorageNonTransactional();
+    return dStorageFactory.getConnector().formatAllStorageNonTransactional();
   }
 
   public static boolean formatStorage(Class<? extends EntityDataAccess>... das)


### PR DESCRIPTION
add a -format option to the resourcemanager that format only the yarn tables in the db

depend on:
hopshadoop/hops-metadata-dal-impl-ndb#55
hopshadoop/hops-metadata-dal#46