### PR TITLE
do not persist price history

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/quota/PriceFixerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/quota/PriceFixerService.java
@@ -242,8 +242,8 @@ public class PriceFixerService extends AbstractService {
         runningPriceDA.add(new YarnRunningPrice(
                 YarnRunningPrice.PriceType.VARIABLE, currentPriceTick,
                 currentPrice));
-        historyPriceDA.add(
-                new YarnHistoryPrice(currentPriceTick, currentPrice));
+//        historyPriceDA.add(
+//                new YarnHistoryPrice(currentPriceTick, currentPrice));
 
         connector.commit();
         return null;


### PR DESCRIPTION
do not persist price history: it is not use right now and it is not garbage collected which result in a "memory leak"