### PR TITLE
Ec on raid5

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hdfs.protocol.HdfsLocatedFileStatus;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.hdfs.security.token.block.InvalidBlockTokenException;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.hdfs.server.blockmanagement.BlockStoragePolicySuite;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
@@ -509,6 +510,18 @@ public class DistributedFileSystem extends FileSystem {
         }
       }
     }.resolve(this, absF);
+  }
+
+  /**
+   * Get the effective storage policy for a file.
+   */
+  public BlockStoragePolicy getStoragePolicy(final Path src) throws IOException {
+    HdfsFileStatus fi = dfs.getFileInfo(getPathName(src));
+    if (fi != null) {
+      return BlockStoragePolicySuite.getPolicy(fi.getStoragePolicy());
+    } else {
+      throw new FileNotFoundException("File does not exist: " + src);
+    }
   }
 
   /** Get all the existing storage policies */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -7423,10 +7423,7 @@ private void commitOrCompleteLastBlock(
       }
     }
 
-    // We always want to store Erasure Coded files on RAID5 volumes, but can
-    // fall back to DISK
-    // Always go for RAID 5 or do we just inherit it?
-//    byte storagePolicyID = HdfsConstants.RAID5_STORAGE_POLICY_ID;
+    // Find which storage policy is used for this file.
     byte storagePolicyID = getINode(sourcePath).getStoragePolicyID();
     BlockStoragePolicy policy = BlockStoragePolicySuite.getPolicy(storagePolicyID);
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -7415,8 +7415,10 @@ private void commitOrCompleteLastBlock(
       }
     }
 
-    // TODO lookup the inodeid, then lookup the storagePolicyID
-    byte storagePolicyID = BlockStoragePolicySuite.ID_UNSPECIFIED;
+    // We always want to store Erasure Coded files on RAID5 volumes, but can
+    // fall back to DISK
+    byte storagePolicyID = HdfsConstants.RAID5_STORAGE_POLICY_ID;
+    BlockStoragePolicy policy = BlockStoragePolicySuite.getPolicy(storagePolicyID);
 
     BlockPlacementPolicyDefault placementPolicy = (BlockPlacementPolicyDefault)
         getBlockManager().getBlockPlacementPolicy();
@@ -7425,8 +7427,7 @@ private void commitOrCompleteLastBlock(
     DatanodeStorageInfo[] descriptors = placementPolicy
         .chooseTarget(isParity ? parityPath : sourcePath,
             isParity ? 1 : status.getEncodingPolicy().getTargetReplication(),
-            null, chosenStorages, false, excluded, block.getBlockSize(),
-            BlockStoragePolicySuite.getPolicy(storagePolicyID));
+            null, chosenStorages, false, excluded, block.getBlockSize(), policy);
 
     return new LocatedBlock(block.getBlock(), descriptors);
   }

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
@@ -250,14 +250,6 @@ public abstract class BaseEncodingManager extends EncodingManager {
         statistics.remainingSize += diskSpace;
         return false;
       }
-
-      // Set the storage policy to RAID5 for disk-fault tolerance
-      srcFs.setStoragePolicy(sourceFile, HdfsConstants.RAID5_STORAGE_POLICY_NAME);
-      // The policy is now updated, but did not change the locations of
-      // blocks yet. This only happens when we trigger the Mover.
-      // TODO
-      // Mover.trigger(sourceFile);
-
     } catch (IOException e) {
       if (out != null) {
         out.close();

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSOutputStream;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.StringUtils;
 import org.json.JSONException;
@@ -249,6 +250,14 @@ public abstract class BaseEncodingManager extends EncodingManager {
         statistics.remainingSize += diskSpace;
         return false;
       }
+
+      // Set the storage policy to RAID5 for disk-fault tolerance
+      srcFs.setStoragePolicy(sourceFile, HdfsConstants.RAID5_STORAGE_POLICY_NAME);
+      // The policy is now updated, but did not change the locations of
+      // blocks yet. This only happens when we trigger the Mover.
+      // TODO
+      // Mover.trigger(sourceFile);
+
     } catch (IOException e) {
       if (out != null) {
         out.close();

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSOutputStream;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
 import org.apache.hadoop.util.Progressable;
 
 import java.io.File;
@@ -146,9 +146,12 @@ public class Encoder {
     FSDataOutputStream out = parityFs.create(parityFile, true,
         conf.getInt("io.file.buffer.size", 64 * 1024), tmpRepl, blockSize);
 
-    // Set the storage policy to RAID5 for disk-fault tolerance
     if(parityFs instanceof DistributedFileSystem) {
-      ((DistributedFileSystem) parityFs).setStoragePolicy(parityFile, HdfsConstants.RAID5_STORAGE_POLICY_NAME);
+      // Get the storage policy of the source file
+      BlockStoragePolicy policy = ((DistributedFileSystem) parityFs).getStoragePolicy(srcFile);
+
+      // And also apply it to the parity file
+      ((DistributedFileSystem) parityFs).setStoragePolicy(parityFile, policy.getName());
     }
 
     DFSOutputStream dfsOut = (DFSOutputStream) out.getWrappedStream();

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSOutputStream;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.util.Progressable;
 
 import java.io.File;
@@ -144,6 +145,11 @@ public class Encoder {
     }
     FSDataOutputStream out = parityFs.create(parityFile, true,
         conf.getInt("io.file.buffer.size", 64 * 1024), tmpRepl, blockSize);
+
+    // Set the storage policy to RAID5 for disk-fault tolerance
+    if(parityFs instanceof DistributedFileSystem) {
+      ((DistributedFileSystem) parityFs).setStoragePolicy(parityFile, HdfsConstants.RAID5_STORAGE_POLICY_NAME);
+    }
 
     DFSOutputStream dfsOut = (DFSOutputStream) out.getWrappedStream();
     dfsOut.enableParityStream(codec.getStripeLength(), codec.getParityLength(),


### PR DESCRIPTION
Makes the erasure coding library play nice with heterogeneous storage.

See issue https://github.com/bcleenders/hops/issues/20 for more info.

#### short description
It keeps the storage policy of the original file; if you wish to use EC+RAID5, just set the storage policy of the file to RAID5 and then erasurecode it. If you wish to use EC+All_SSD, just set the policy to All_SSD and then erasurecode it, etc.

You can also change the storage policy of an erasurecoded file (just call setStoragePolicy on it). However, this won't move the parity file(s). Even if you call Mover, only the data blocks move, not the parity block(s). This is due to the design of the EC library which stores the parity blocks as a separate file, which makes syncing the storage policies a bit more complicated.

Shouldn't be a problem for now, though. If you know the location of the parity blocks, you can even just call setStoragePolicy on them too 😃