### PR TITLE
avoid useless users creation in the hdfs_users tables, when doing doA…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -635,7 +635,7 @@ public class UserGroupInformation {
       return getLoginUser();
     } else {
       return new UserGroupInformation(subject);
-    }
+          }
   }
 
   /**
@@ -1221,23 +1221,51 @@ public class UserGroupInformation {
    * Create a user from a login name. It is intended to be used for remote
    * users in RPC, since it won't have any credentials.
    * @param user the full user principal name, must not be empty or null
+   * @param createHops add user to hdfs_users or not
    * @return the UserGroupInformation for the remote user.
    */
   @InterfaceAudience.Public
   @InterfaceStability.Evolving
+  public static UserGroupInformation createRemoteUser(String user, boolean createHops) {
+    return createRemoteUser(user, AuthMethod.SIMPLE, createHops);
+  }
+  
+  /**
+   * Create a user from a login name. It is intended to be used for remote
+   * users in RPC, since it won't have any credentials.
+   * automatically add user to hdfs_users.
+   * @param user the full user principal name, must not be empty or null
+   * @return the UserGroupInformation for the remote user.
+   */
   public static UserGroupInformation createRemoteUser(String user) {
-    return createRemoteUser(user, AuthMethod.SIMPLE);
+    return createRemoteUser(user, AuthMethod.SIMPLE, true);
   }
   
   /**
    * Create a user from a login name. It is intended to be used for remote
    * users in RPC, since it won't have any credentials.
    * @param user the full user principal name, must not be empty or null
+   * @param authMethod the authentication method to use
    * @return the UserGroupInformation for the remote user.
    */
   @InterfaceAudience.Public
   @InterfaceStability.Evolving
   public static UserGroupInformation createRemoteUser(String user, AuthMethod authMethod) {
+    return createRemoteUser(user, authMethod, true);
+  }
+  
+  /**
+   * Create a user from a login name. It is intended to be used for remote
+   * users in RPC, since it won't have any credentials.
+   * @param user the full user principal name, must not be empty or null
+   * @param authMethod the authentication method to use
+   * @param createHops add user to hdfs_users or not
+   * @return the UserGroupInformation for the remote user.
+   */
+  @InterfaceAudience.Public
+  @InterfaceStability.Evolving
+  public static UserGroupInformation createRemoteUser(String user, AuthMethod authMethod,
+          boolean createHops) {
     if (user == null || user.isEmpty()) {
       throw new IllegalArgumentException("Null user");
     }
@@ -1245,7 +1273,9 @@ public class UserGroupInformation {
     subject.getPrincipals().add(new User(user));
     UserGroupInformation result = new UserGroupInformation(subject);
     result.setAuthenticationMethod(authMethod);
-    createHopsUser(user);
+    if(createHops){
+      createHopsUser(user);
+    }
     return result;
   }
 
@@ -1311,6 +1341,21 @@ public class UserGroupInformation {
   @InterfaceStability.Evolving
   public static UserGroupInformation createProxyUser(String user,
       UserGroupInformation realUser) {
+    return createProxyUser(user, realUser, true);
+  }
+  
+  /**
+   * Create a proxy user using username of the effective user and the ugi of the
+   * real user.
+   * @param user
+   * @param realUser
+   * @param createHops
+   * @return proxyUser ugi
+   */
+  @InterfaceAudience.Public
+  @InterfaceStability.Evolving
+  public static UserGroupInformation createProxyUser(String user,
+      UserGroupInformation realUser, boolean createHops) {
     if (user == null || user.isEmpty()) {
       throw new IllegalArgumentException("Null user");
     }
@@ -1323,7 +1368,9 @@ public class UserGroupInformation {
     principals.add(new RealUser(realUser));
     UserGroupInformation result =new UserGroupInformation(subject);
     result.setAuthenticationMethod(AuthenticationMethod.PROXY);
-    createHopsUser(user);
+    if(createHops){
+      createHopsUser(user);
+    }
     return result;
   }
 

--- a/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/appmaster/AMSimulator.java
+++ b/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/appmaster/AMSimulator.java
@@ -274,7 +274,8 @@ public abstract class AMSimulator extends TaskRunner.Task {
     try {
 
       UserGroupInformation ugi = UserGroupInformation.createProxyUser(
-              appAttemptId.toString(), UserGroupInformation.getCurrentUser());
+              appAttemptId.toString(), UserGroupInformation.getCurrentUser(),
+              false);
       ugi.setAuthenticationMethod(SaslRpcServer.AuthMethod.TOKEN);
       ugi.addCredentials(credentials);
       ugi.addToken(amRMToken);
@@ -361,7 +362,8 @@ public abstract class AMSimulator extends TaskRunner.Task {
     LOG.info("register application master for " + appId);
 
     UserGroupInformation ugi = UserGroupInformation.createProxyUser(
-            appAttemptId.toString(), UserGroupInformation.getCurrentUser());
+            appAttemptId.toString(), UserGroupInformation.getCurrentUser(),
+            false);
     ugi.setAuthenticationMethod(SaslRpcServer.AuthMethod.TOKEN);
     ugi.addCredentials(credentials);
     ugi.addToken(amRMToken);

--- a/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/appmaster/MRAMSimulator.java
+++ b/hadoop-tools/distributedLoadSimulator/src/main/java/org/apache/hadoop/distributedloadsimulator/sls/appmaster/MRAMSimulator.java
@@ -230,7 +230,8 @@ public class MRAMSimulator extends AMSimulator {
 
     AllocateResponse response = null;
     UserGroupInformation ugi = UserGroupInformation.createProxyUser(
-            appAttemptId.toString(), UserGroupInformation.getCurrentUser());
+            appAttemptId.toString(), UserGroupInformation.getCurrentUser(),
+            false);
     ugi.setAuthenticationMethod(SaslRpcServer.AuthMethod.TOKEN);
     ugi.addCredentials(credentials);
     ugi.addToken(amRMToken);
@@ -482,7 +483,8 @@ public class MRAMSimulator extends AMSimulator {
 
     AllocateResponse response = null;
     UserGroupInformation ugi = UserGroupInformation.createProxyUser(
-            appAttemptId.toString(), UserGroupInformation.getCurrentUser());
+            appAttemptId.toString(), UserGroupInformation.getCurrentUser(),
+            false);
     ugi.setAuthenticationMethod(SaslRpcServer.AuthMethod.TOKEN);
     ugi.addCredentials(credentials);
     ugi.addToken(amRMToken);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/AMRMTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/AMRMTokenIdentifier.java
@@ -92,8 +92,8 @@ public class AMRMTokenIdentifier extends TokenIdentifier {
     if (proto.hasAppAttemptId()) {
       appAttemptId = 
           new ApplicationAttemptIdPBImpl(proto.getAppAttemptId()).toString();
-    }
-    return UserGroupInformation.createRemoteUser(appAttemptId);
+  }
+    return UserGroupInformation.createRemoteUser(appAttemptId, false);
   }
 
   public int getKeyId() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/NMTokenIdentifier.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/security/NMTokenIdentifier.java
@@ -113,8 +113,8 @@ public class NMTokenIdentifier extends TokenIdentifier {
     if (proto.hasAppAttemptId()) {
       appAttemptId = new ApplicationAttemptIdPBImpl(
           proto.getAppAttemptId()).toString();
-    }
-    return UserGroupInformation.createRemoteUser(appAttemptId);
+  }
+    return UserGroupInformation.createRemoteUser(appAttemptId, false);
   }
   
   public NMTokenIdentifierProto getProto() {


### PR DESCRIPTION
…s in Yarn.