### PR TITLE
Fixes HOPS-35

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/context/MetadataLogContext.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/context/MetadataLogContext.java
@@ -17,14 +17,9 @@ package io.hops.transaction.context;
 
 import io.hops.exception.StorageException;
 import io.hops.exception.TransactionContextException;
-import io.hops.metadata.common.FinderType;
 import io.hops.metadata.hdfs.dal.MetadataLogDataAccess;
 import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.transaction.lock.TransactionLocks;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 
 public class MetadataLogContext
     extends BaseEntityContext<MetadataLogContext.Key, MetadataLogEntry> {
@@ -83,10 +78,9 @@ public class MetadataLogContext
       key.timestamp = logEntry.updateTimestamp();
     }
     super.add(logEntry);
-    log("metadata-log-added","baseDirId", logEntry.getDatasetId(), "inodeId",logEntry.getInodeId(),"name", logEntry.getInodeName(), "pid", logEntry.getInodeParentId(), "Operation", logEntry.getOperation());
-          for(int i = 0;i < Thread.currentThread().getStackTrace().length;i++){
-        System.out.println((Thread.currentThread().getStackTrace()[i]));
-      }
+    log("metadata-log-added","baseDirId", logEntry.getDatasetId(), "inodeId",
+        logEntry.getInodeId(),"name", logEntry.getInodeName(), "pid",
+        logEntry.getInodeParentId(), "Operation", logEntry.getOperation());
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/AbstractFileTree.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/AbstractFileTree.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.security.AccessControlException;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
@@ -431,8 +432,8 @@ abstract class AbstractFileTree {
   }
 
   static class LoggingQuotaCountingFileTree extends QuotaCountingFileTree {
-    private LinkedList<MetadataLogEntry> metadataLogEntries =
-        new LinkedList<MetadataLogEntry>();
+    private ConcurrentLinkedQueue<MetadataLogEntry> metadataLogEntries =
+        new ConcurrentLinkedQueue<>();
     private final INode srcDataset;
     private final INode dstDataset;
     public LoggingQuotaCountingFileTree(

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -6328,7 +6328,8 @@ public class FSNamesystem
 
         if (srcSubTreeRoot != null) {
           AbstractFileTree.QuotaCountingFileTree srcFileTree;
-          if (pathIsMetaEnabled(srcInodes) || pathIsMetaEnabled(dstInodes)) {
+          if (shouldLogSubtreeInodes(srcInfo, dstInfo, srcDataset,
+              dstDataset, srcSubTreeRoot)) {
             srcFileTree = new AbstractFileTree.LoggingQuotaCountingFileTree(this,
                     srcSubTreeRoot, srcDataset, dstDataset);
             srcFileTree.buildUp();
@@ -6563,7 +6564,8 @@ public class FSNamesystem
 
         if (srcSubTreeRoot != null) {
           AbstractFileTree.QuotaCountingFileTree srcFileTree;
-          if (pathIsMetaEnabled(srcInfo.pathInodes) || pathIsMetaEnabled(dstInfo.pathInodes)) {
+          if (shouldLogSubtreeInodes(srcInfo, dstInfo, srcDataset,
+              dstDataset, srcSubTreeRoot)) {
             srcFileTree = new AbstractFileTree.LoggingQuotaCountingFileTree(this,
                     srcSubTreeRoot, srcDataset, dstDataset);
             srcFileTree.buildUp();
@@ -6595,6 +6597,18 @@ public class FSNamesystem
         }
      }
     }
+  }
+
+  private boolean shouldLogSubtreeInodes(PathInformation srcInfo,
+      PathInformation dstInfo, INode srcDataset, INode dstDataset,
+      INodeIdentifier srcSubTreeRoot){
+    if(pathIsMetaEnabled(srcInfo.pathInodes) || pathIsMetaEnabled(dstInfo
+        .pathInodes)){
+      boolean isRenameLocalOrRenameDataset = dstDataset == null ? srcDataset
+          .equalsIdentifier(srcSubTreeRoot) : srcDataset.equals(dstDataset);
+      return !isRenameLocalOrRenameDataset;
+    }
+    return false;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/INode.java
@@ -23,6 +23,7 @@ import io.hops.exception.StorageException;
 import io.hops.exception.TransactionContextException;
 import io.hops.metadata.common.FinderType;
 import io.hops.metadata.hdfs.entity.EncodingStatus;
+import io.hops.metadata.hdfs.entity.INodeIdentifier;
 import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.security.UsersGroups;
 import io.hops.transaction.EntityManager;
@@ -944,5 +945,27 @@ public abstract class INode implements Comparable<byte[]> {
 
     INode parentInode = EntityManager.find(Finder.ByINodeIdFTIS, getParentId());
     return (short) (parentInode.myDepth()+1);
+  }
+
+  public boolean equalsIdentifier(INodeIdentifier iNodeIdentifier){
+    if(iNodeIdentifier == null)
+      return false;
+
+    if(getId() != iNodeIdentifier.getInodeId())
+      return false;
+
+    if(getParentId() != iNodeIdentifier.getPid())
+      return false;
+
+    if(iNodeIdentifier.getPartitionId() == null)
+      return false;
+
+    if(!getPartitionId().equals(iNodeIdentifier.getPartitionId()))
+      return false;
+
+    if(!getLocalName().equals(iNodeIdentifier.getName()))
+      return false;
+
+    return true;
   }
 }


### PR DESCRIPTION
Add log entries for a subtree only when you rename across different metaEnabled directories