### PR TITLE
HOPS-47

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/pom.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/pom.xml
@@ -200,6 +200,12 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>netty</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/security/TestUsersGroups.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/security/TestUsersGroups.java
@@ -30,12 +30,14 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.ipc.RemoteException;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
@@ -251,10 +253,10 @@ public class TestUsersGroups {
     int groupId = UsersGroups.getGroupID("group1");
     assertNotSame(0, groupId);
     assertEquals(UsersGroups.getGroup(groupId), "group1");
-
-    assertEquals(UsersGroups.getGroups("user"), Arrays.asList("group1",
-        "group2"));
-
+    
+    assertThat(UsersGroups.getGroups("user"), Matchers.containsInAnyOrder
+        ("group1", "group2"));
+    
     removeUser(userId);
 
     userId = UsersGroups.getUserID("user");
@@ -276,9 +278,10 @@ public class TestUsersGroups {
 
     userId = UsersGroups.getUserID("user");
     assertNotSame(0, userId);
-
-    assertEquals(Arrays.asList("group1", "group2"), UsersGroups.getGroups("user"));
-
+    
+    assertThat(UsersGroups.getGroups("user"), Matchers.containsInAnyOrder
+        ("group1", "group2"));
+    
     removeUser(userId);
 
     UsersGroups.addUserToGroupsTx("user", new String[]{"group3"});
@@ -291,10 +294,9 @@ public class TestUsersGroups {
 
     UsersGroups.addUserToGroupsTx("user", new String[]{"group1",
         "group2"});
-
-    assertEquals(Arrays.asList("group3",
-        "group1", "group2"), UsersGroups.getGroups("user"));
-
+    
+    assertThat(UsersGroups.getGroups("user"), Matchers.containsInAnyOrder
+        ("group1", "group2", "group3"));
     UsersGroups.stop();
   }
 
@@ -316,10 +318,10 @@ public class TestUsersGroups {
     int groupId = UsersGroups.getGroupID("group1");
     assertNotSame(0, groupId);
     assertEquals(UsersGroups.getGroup(groupId), "group1");
-
-    assertEquals(UsersGroups.getGroups("user"), Arrays.asList("group1",
-        "group2"));
-
+  
+    assertThat(UsersGroups.getGroups("user"), Matchers.containsInAnyOrder
+        ("group1", "group2"));
+    
     removeUser(userId);
 
     userId = UsersGroups.getUserID("user");
@@ -336,8 +338,9 @@ public class TestUsersGroups {
 
     userId = UsersGroups.getUserID("user");
     assertNotSame(0, userId);
-
-    assertEquals(Arrays.asList("group1", "group2"), UsersGroups.getGroups("user"));
+  
+    assertThat(UsersGroups.getGroups("user"), Matchers.containsInAnyOrder
+        ("group1", "group2"));
 
     removeUser(userId);
 
@@ -351,9 +354,9 @@ public class TestUsersGroups {
 
     UsersGroups.addUserToGroupsTx("user", new String[]{"group1",
         "group2"});
-
-    assertEquals(Arrays.asList("group3",
-        "group1", "group2"), UsersGroups.getGroups("user"));
+    
+    assertThat(UsersGroups.getGroups("user"), Matchers.containsInAnyOrder
+        ("group1", "group2", "group3"));
 
     cluster.shutdown();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
     <curator.version>2.7.1</curator.version>
+    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
TestUsersGroups was failing because JUnit checks also the order of the elements in two lists

https://hopshadoop.atlassian.net/browse/HOPS-47