### PR TITLE
HOPS-68

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -40,6 +40,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.hops</groupId>
       <artifactId>hadoop-annotations</artifactId>
       <scope>compile</scope>

--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsUtil.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.security;
+
+import com.google.common.io.ByteStreams;
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.net.util.Base64;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.net.HopsSSLSocketFactory;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import javax.ws.rs.core.MediaType;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class HopsUtil {
+  
+  private static final Log LOG = LogFactory.getLog(HopsUtil.class);
+  
+  private static final String CERT_PASS_RESOURCE =
+      "/hopsworks-api/api/appservice/certpw";
+  
+  /**
+   * Makes a REST call to Hopsworks to get the password of a keystore
+   * associated with a Hopsworks user
+   * @param keyStore Binary form of the keystore
+   * @param username Username associated with the certificate
+   * @param conf Hadoop configuration object
+   * @return Password of the keystore, it is the same for the truststore
+   * @throws JSONException
+   * @throws IOException
+   */
+  public static String getCertificatePasswordFromHopsworks(byte[] keyStore,
+      String username, Configuration conf) throws JSONException, IOException {
+    String keystoreEncoded = Base64.encodeBase64String(keyStore);
+    return getCertPassFromHwInternal(keystoreEncoded, username, conf);
+  }
+  
+  /**
+   * Makes a REST call to Hopsworks to get the password of a keystore
+   * associated with a Hopsworks user
+   * @param keyStorePath Path in the local filesystem of the keystore
+   * @param username Username associated with the certificate
+   * @param conf Hadoop configuration object
+   * @return Password of the keystore, it is the same for the truststore
+   * @throws JSONException
+   * @throws IOException
+   */
+  public static String getCertificatePasswordFromHopsworks(String keyStorePath,
+      String username, Configuration conf) throws JSONException, IOException {
+    String keyStoreEncoded = keystoreEncode(keyStorePath);
+    return getCertPassFromHwInternal(keyStoreEncoded, username, conf);
+  }
+  
+  private static String getCertPassFromHwInternal(String keyStoreEncoded,
+      String username, Configuration conf) throws JSONException, IOException {
+    String uri = getUriForCertPassword(conf);
+    
+    Client client = Client.create();
+    WebResource resource = client.resource(uri);
+    ClientResponse response = resource
+        .queryParam("keyStore", keyStoreEncoded)
+        .queryParam("projectUser", username)
+        .type(MediaType.TEXT_PLAIN)
+        .get(ClientResponse.class);
+    
+    JSONObject jsonObj = new JSONObject(response.getEntity(String.class));
+  
+    return jsonObj.getString("keyPw");
+  }
+  
+  private static String keystoreEncode(String keyStorePath) throws IOException {
+    FileInputStream keyStoreInStream = new FileInputStream(
+        new File(keyStorePath));
+    byte[] kStoreBlob = ByteStreams.toByteArray(keyStoreInStream);
+    return Base64.encodeBase64String(kStoreBlob);
+  }
+  
+  private static String getUriForCertPassword(Configuration conf)
+    throws IOException {
+    return getHopsworksEndpoint(conf) + CERT_PASS_RESOURCE;
+  }
+  
+  private static String getHopsworksEndpoint(Configuration conf)
+    throws IOException {
+    String hopsworksEndpoint = conf.get(HopsSSLSocketFactory
+        .HOPSWORKS_REST_ENDPOINT_KEY);
+    if (hopsworksEndpoint == null) {
+      throw new IOException("Configuration property " + HopsSSLSocketFactory
+          .HOPSWORKS_REST_ENDPOINT_KEY + " has not been set");
+    }
+    
+    return hopsworksEndpoint;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CertificateLocalization.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CertificateLocalization.java
@@ -24,11 +24,16 @@ import java.util.concurrent.ExecutionException;
 
 public interface CertificateLocalization {
   void materializeCertificates(String username,
-      ByteBuffer keyStore, ByteBuffer trustStore) throws IOException;
+      ByteBuffer keyStore, String keyStorePassword,
+      ByteBuffer trustStore, String trustStorePassword) throws IOException;
   
   void removeMaterial(String username)
     throws InterruptedException, ExecutionException;
   
   CryptoMaterial getMaterialLocation(String username)
       throws FileNotFoundException, InterruptedException, ExecutionException;
+  
+  String getSuperKeystorePass();
+  
+  String getSuperTruststorePass();
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CryptoMaterial.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CryptoMaterial.java
@@ -25,7 +25,9 @@ public class CryptoMaterial {
   private final String trustStoreLocation;
   private final int trustStoreSize;
   private final ByteBuffer keyStoreMem;
+  private final String keyStorePass;
   private final ByteBuffer trustStoreMem;
+  private final String trustStorePass;
   
   // Number of applications using the same crypto material
   // The same user might have multiple applications running
@@ -33,14 +35,17 @@ public class CryptoMaterial {
   private int requestedApplications;
   
   public CryptoMaterial(String keyStoreLocation, String trustStoreLocation,
-      ByteBuffer kStore, ByteBuffer tstore) {
+      ByteBuffer kStore, String kStorePass,
+      ByteBuffer tstore, String tstorePass) {
     this.keyStoreLocation = keyStoreLocation;
     this.keyStoreSize = kStore.capacity();
     this.trustStoreLocation = trustStoreLocation;
     this.trustStoreSize = tstore.capacity();
     
     this.keyStoreMem = kStore.asReadOnlyBuffer();
+    this.keyStorePass = kStorePass;
     this.trustStoreMem = tstore.asReadOnlyBuffer();
+    this.trustStorePass = tstorePass;
     
     requestedApplications = 1;
   }
@@ -65,8 +70,16 @@ public class CryptoMaterial {
     return keyStoreMem;
   }
   
+  public String getKeyStorePass() {
+    return keyStorePass;
+  }
+  
   public ByteBuffer getTrustStoreMem() {
     return trustStoreMem;
+  }
+  
+  public String getTrustStorePass() {
+    return trustStorePass;
   }
   
   public int getRequestedApplications() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/StartContainersRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/StartContainersRequest.java
@@ -86,9 +86,25 @@ public abstract class StartContainersRequest {
   
   @Public
   @InterfaceStability.Unstable
+  public abstract String getKeyStorePassword();
+  
+  @Public
+  @InterfaceStability.Unstable
+  public abstract void setKeyStorePassword(String password);
+  
+  @Public
+  @InterfaceStability.Unstable
   public abstract ByteBuffer getTrustStore();
   
   @Public
   @InterfaceStability.Unstable
   public abstract void setTrustStore(ByteBuffer trustStore);
+  
+  @Public
+  @InterfaceStability.Unstable
+  public abstract String getTrustStorePassword();
+  
+  @Public
+  @InterfaceStability.Unstable
+  public abstract void setTrustStorePassword(String password);
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ApplicationSubmissionContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ApplicationSubmissionContext.java
@@ -547,9 +547,25 @@ public abstract class ApplicationSubmissionContext {
   
   @Public
   @Unstable
+  public abstract String getKeyStorePassword();
+  
+  @Public
+  @Unstable
+  public abstract void setKeyStorePassword(String password);
+  
+  @Public
+  @Unstable
   public abstract ByteBuffer getTrustStore();
   
   @Public
   @Unstable
   public abstract void setTrustStore(ByteBuffer trustStore);
+  
+  @Public
+  @Unstable
+  public abstract String getTrustStorePassword();
+  
+  @Public
+  @Unstable
+  public abstract void setTrustStorePassword(String password);
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_protos.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_protos.proto
@@ -360,7 +360,9 @@ message ApplicationSubmissionContextProto {
   optional string node_label_expression = 16;
   optional ResourceRequestProto am_container_resource_request = 17;
   optional bytes key_store = 18;
-  optional bytes trust_store = 19;
+  optional string key_store_password = 19;
+  optional bytes trust_store = 20;
+  optional string trust_store_password = 21;
 }
 
 message LogAggregationContextProto {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_service_protos.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_service_protos.proto
@@ -294,7 +294,9 @@ message StopContainerResponseProto {
 message StartContainersRequestProto {
   repeated StartContainerRequestProto start_container_request = 1;
   optional bytes key_store = 2;
-  optional bytes trust_store = 3;
+  optional string key_store_password = 3;
+  optional bytes trust_store = 4;
+  optional string trust_store_password = 5;
 }
 
 message ContainerExceptionMapProto {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/StartContainersRequestPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/protocolrecords/impl/pb/StartContainersRequestPBImpl.java
@@ -160,6 +160,25 @@ public class StartContainersRequestPBImpl extends StartContainersRequest {
   }
   
   @Override
+  public String getKeyStorePassword() {
+    StartContainersRequestProtoOrBuilder p = viaProto ? proto : builder;
+    if (!p.hasKeyStorePassword()) {
+      return null;
+    }
+    return p.getKeyStorePassword();
+  }
+  
+  @Override
+  public void setKeyStorePassword(String password) {
+    maybeInitBuilder();
+    if (password == null) {
+      builder.clearKeyStorePassword();
+      return;
+    }
+    builder.setKeyStorePassword(password);
+  }
+  
+  @Override
   public ByteBuffer getTrustStore() {
     StartContainersRequestProtoOrBuilder p = viaProto ? proto : builder;
     if (this.trustStore != null) {
@@ -179,6 +198,25 @@ public class StartContainersRequestPBImpl extends StartContainersRequest {
       builder.clearTrustStore();
     }
     this.trustStore = trustStore;
+  }
+  
+  @Override
+  public String getTrustStorePassword() {
+    StartContainersRequestProtoOrBuilder p = viaProto ? proto : builder;
+    if (!p.hasTrustStorePassword()) {
+      return null;
+    }
+    return p.getTrustStorePassword();
+  }
+  
+  @Override
+  public void setTrustStorePassword(String password) {
+    maybeInitBuilder();
+    if (password == null) {
+      builder.clearTrustStorePassword();
+      return;
+    }
+    builder.setTrustStorePassword(password);
   }
   
   private ByteBuffer convertFromProtoFormat(ByteString byteString) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ApplicationSubmissionContextPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ApplicationSubmissionContextPBImpl.java
@@ -444,7 +444,26 @@ extends ApplicationSubmissionContext {
     }
     this.keyStore = keyStore;
   }
-
+  
+  @Override
+  public String getKeyStorePassword() {
+    ApplicationSubmissionContextProtoOrBuilder p = viaProto ? proto : builder;
+    if (!p.hasKeyStorePassword()) {
+      return null;
+    }
+    return p.getKeyStorePassword();
+  }
+  
+  @Override
+  public void setKeyStorePassword(String password) {
+    maybeInitBuilder();
+    if (password == null) {
+      builder.clearKeyStorePassword();
+      return;
+    }
+    builder.setKeyStorePassword(password);
+  }
+  
   @Override
   public ByteBuffer getTrustStore() {
     ApplicationSubmissionContextProtoOrBuilder p = viaProto ? proto : builder;
@@ -465,6 +484,25 @@ extends ApplicationSubmissionContext {
       builder.clearTrustStore();
     }
     this.trustStore = trustStore;
+  }
+  
+  @Override
+  public String getTrustStorePassword() {
+    ApplicationSubmissionContextProtoOrBuilder p = viaProto ? proto : builder;
+    if (!p.hasTrustStorePassword()) {
+      return null;
+    }
+    return p.getTrustStorePassword();
+  }
+  
+  @Override
+  public void setTrustStorePassword(String password) {
+    maybeInitBuilder();
+    if (password == null) {
+      builder.clearTrustStorePassword();
+      return;
+    }
+    builder.setTrustStorePassword(password);
   }
   
   private PriorityPBImpl convertFromProtoFormat(PriorityProto p) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/protocolrecords/MaterializeCryptoKeysRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/protocolrecords/MaterializeCryptoKeysRequest.java
@@ -42,9 +42,17 @@ public abstract class MaterializeCryptoKeysRequest {
   
   public abstract void setKeystore(ByteBuffer keystore);
   
+  public abstract String getKeystorePassword();
+  
+  public abstract void setKeystorePassword(String password);
+  
   public abstract ByteBuffer getTruststore();
   
   public abstract void setTruststore(ByteBuffer truststore);
+  
+  public abstract String getTruststorePassword();
+  
+  public abstract void setTruststorePassword(String password);
   
   @Override
   public String toString() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/protocolrecords/impl/pb/MaterializeCryptoKeysRequestPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/api/protocolrecords/impl/pb/MaterializeCryptoKeysRequestPBImpl.java
@@ -107,6 +107,24 @@ public class MaterializeCryptoKeysRequestPBImpl extends
   }
   
   @Override
+  public String getKeystorePassword() {
+    YarnServerCommonServiceProtos.MaterializeCryptoKeysRequestProtoOrBuilder p =
+        viaProto ? proto : builder;
+    
+    return (p.hasKeystorePassword()) ? p.getKeystorePassword() : null;
+  }
+  
+  @Override
+  public void setKeystorePassword(String password) {
+    maybeInitBuilder();
+    if (password == null) {
+      builder.clearKeystorePassword();
+      return;
+    }
+    builder.setKeystorePassword(password);
+  }
+  
+  @Override
   public ByteBuffer getTruststore() {
     YarnServerCommonServiceProtos.MaterializeCryptoKeysRequestProtoOrBuilder p =
         viaProto ? proto : builder;
@@ -126,5 +144,23 @@ public class MaterializeCryptoKeysRequestPBImpl extends
       return;
     }
     builder.setTruststore(ProtoUtils.convertToProtoFormat(truststore));
+  }
+  
+  @Override
+  public String getTruststorePassword() {
+    YarnServerCommonServiceProtos.MaterializeCryptoKeysRequestProtoOrBuilder p =
+        viaProto ? proto : builder;
+    
+    return (p.hasTruststorePassword()) ? p.getTruststorePassword() : null;
+  }
+  
+  @Override
+  public void setTruststorePassword(String password) {
+    maybeInitBuilder();
+    if (password == null) {
+      builder.clearTruststorePassword();
+      return;
+    }
+    builder.setTruststorePassword(password);
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/proto/yarn_server_common_service_protos.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/proto/yarn_server_common_service_protos.proto
@@ -127,7 +127,9 @@ message SCMUploaderCanUploadResponseProto {
 message MaterializeCryptoKeysRequestProto {
   required string username = 1;
   required bytes keystore = 2;
-  required bytes truststore = 3;
+  required string keystore_password = 3;
+  required bytes truststore = 4;
+  required string truststore_password = 5;
 }
 
 message MaterializeCryptoKeysResponseProto {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/ContainerManagerImpl.java
@@ -850,7 +850,10 @@ public class ContainerManagerImpl extends CompositeService implements
           .getContainerToken()).getApplicationSubmitter();
     }
     ByteBuffer keyStore = requests.getKeyStore();
+    String keyStorePass = requests.getKeyStorePassword();
     ByteBuffer trustStore = requests.getTrustStore();
+    String trustStorePass = requests.getTrustStorePassword();
+    
     if (user == null) {
       throw new IOException("Submitter user is null");
     }
@@ -860,8 +863,16 @@ public class ContainerManagerImpl extends CompositeService implements
           "supplied is either null or empty");
     }
     
-    context.getCertificateLocalizationService().materializeCertificates(user,
-        keyStore, trustStore);
+
+    // ApplicationMasters will also call startContainers() through NMClient
+    // In that case there will be no password set for keystore and truststore
+    // Only RM will set these values when launching AM container through the
+    // AMLauncher
+    if (keyStorePass != null && !keyStorePass.isEmpty()
+        && trustStorePass != null && !trustStorePass.isEmpty()) {
+      context.getCertificateLocalizationService().materializeCertificates(user,
+          keyStore, keyStorePass, trustStore, trustStorePass);
+    }
   }
   
   private ContainerManagerApplicationProto buildAppProto(ApplicationId appId,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
@@ -591,11 +591,15 @@ public class ClientRMService extends AbstractService implements
         .IPC_SERVER_SSL_ENABLED_DEFAULT)) {
   
       ByteBuffer kstore = submissionContext.getKeyStore();
+      String kstorePass = submissionContext.getKeyStorePassword();
       ByteBuffer tstore = submissionContext.getTrustStore();
+      String tstorePass = submissionContext.getTrustStorePassword();
+      
       try {
-        if (kstore == null || tstore == null) {
+        if (kstore == null || tstore == null
+            || kstorePass.isEmpty() || tstorePass.isEmpty()) {
           throw new IOException("RPC TLS is enabled but either keystore or " +
-              "truststore is null");
+              "truststore is null or no password provided");
         }
         if (kstore.capacity() == 0 || tstore.capacity() == 0) {
           throw new IOException("RPC TLS is enabled but either keystore or " +
@@ -603,7 +607,7 @@ public class ClientRMService extends AbstractService implements
         }
         
         rmContext.getCertificateLocalizationService().materializeCertificates
-            (username, kstore, tstore);
+            (username, kstore, kstorePass, tstore, tstorePass);
       } catch (IOException ex) {
         LOG.error(ex, ex);
         RMAuditLogger.logFailure(user, AuditConstants.SUBMIT_APP_REQUEST,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/amlauncher/AMLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/amlauncher/AMLauncher.java
@@ -154,7 +154,9 @@ public class AMLauncher implements Runnable {
       CryptoMaterial material = rmContext
           .getCertificateLocalizationService().getMaterialLocation(user);
       request.setKeyStore(material.getKeyStoreMem());
+      request.setKeyStorePassword(material.getKeyStorePass());
       request.setTrustStore(material.getTrustStoreMem());
+      request.setTrustStorePassword(material.getTrustStorePass());
     } catch (InterruptedException | ExecutionException e) {
       throw new YarnException("Execution of CertificateMaterializer " +
           "interrupted", e);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnSSLServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnSSLServer.java
@@ -146,10 +146,13 @@ public class TestYarnSSLServer extends HopsSSLTestUtils {
         appCtx.setQueue("default");
     
         //ByteBuffer[] material = getCryptoMaterial();
-        ByteBuffer lala = ByteBuffer.allocate(5000);
-        ByteBuffer koko = ByteBuffer.allocate(5000);
-        appCtx.setKeyStore(lala);
-        appCtx.setTrustStore(koko);
+        ByteBuffer kstore = ByteBuffer.allocate(5000);
+        ByteBuffer tstore = ByteBuffer.allocate(5000);
+        String pass = "password";
+        appCtx.setKeyStore(kstore);
+        appCtx.setKeyStorePassword(pass);
+        appCtx.setTrustStore(tstore);
+        appCtx.setTrustStorePassword(pass);
     
         ApplicationClientProtocol client = ClientRMProxy.createRMProxy(conf,
             ApplicationClientProtocol.class, true);


### PR DESCRIPTION
[HOPS-68] Store keystore and truststore password in CertificateLocalizationService. Pass them along with the ApplicationSubmissionContext and StartContainersRequest RPC

[HOPS-68] Fix tests for CertificateLocalizationService

[HOPS-68] Add keystore and truststore password in the CertificateLocalizationService sync protocol

[HOPS-68] Fix tests for CertificateLocalizationService sync protocol

[HOPS-68] Change the way I get the passwords for keystore and truststore

[HOPS-68] Make a REST call to Hopsworks to get the password for a keystore

[HOPS-68] Refactor REST call to Hopsworks

[HOPS-68] Fix failing SSL related tests

https://hopshadoop.atlassian.net/browse/HOPS-68