### PR TITLE
HOPS-76

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
@@ -58,7 +58,7 @@ public class ProcfsBasedProcessTree extends ResourceCalculatorProcessTree {
   private static final String PROCFS = "/proc/";
 
   private static final Pattern PROCFS_STAT_FILE_FORMAT = Pattern.compile(
-      "^([\\d-]+)\\s\\(([^)]+)\\)\\s[^\\s]\\s([\\d-]+)\\s([\\d-]+)\\s" +
+      "^([\\d-]+)\\s[\\(]{1,2}([^)]+)[\\)]{1,2}\\s[^\\s]\\s([\\d-]+)\\s([\\d-]+)\\s" +
       "([\\d-]+)\\s([\\d-]+\\s){7}(\\d+)\\s(\\d+)\\s([\\d-]+\\s){7}(\\d+)\\s" +
       "(\\d+)(\\s[\\d-]+){15}");
 


### PR DESCRIPTION
[HOPS-76] Fix bug with double parentheses in the process name

https://hopshadoop.atlassian.net/browse/HOPS-76