### PR TITLE
HOPS-84 hadoop-common pom.xml should include hops-gpu-management dependency

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -311,6 +311,11 @@
       <artifactId>concurrentlinkedhashmap-lru</artifactId>
       <version>1.4.2</version>
     </dependency>
+    <dependency>
+      <groupId>io.hops.gpu</groupId>
+      <artifactId>hops-gpu-management</artifactId>
+      <version>1.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
After upgrading to 2.8.2 SysInfoLinux located in hadoop-common replaced LinuxResourceCalculatorPlugin located in hadoop-yarn-common. hadoop-common pom.xml needs to be updated to include hops-gpu-management depdendency.