### PR TITLE
Revert "HOPS-82 Ignore unusable GPUs on NM"

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/io/hops/devices/GPUAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/io/hops/devices/GPUAllocator.java
@@ -80,10 +80,10 @@ public class GPUAllocator {
       try {
         initMandatoryDrivers();
         initConfiguredGPUs(numGPUs);
-        initTotalGPUs();
       } catch (IOException ioe) {
         ioe.printStackTrace();
       }
+      initTotalGPUs();
     }
     return this.initialized;
   }
@@ -163,8 +163,14 @@ public class GPUAllocator {
     }
   }
 
+  //If 3 GPUs exist, the numbering is 195:0 195:1 195:2
   private void initTotalGPUs() {
-    totalGPUs = new HashSet<>(configuredAvailableGPUs);
+    int totalNumGPUs= gpuManagementLibrary.getNumGPUs();
+    while(totalNumGPUs != 0) {
+      totalGPUs.add(new Device(NVIDIA_GPU_MAJOR_DEVICE_NUMBER, totalNumGPUs-1));
+      totalNumGPUs--;
+    }
+    LOG.info("Total GPUs present on machine " + totalGPUs);
   }
   
   /**

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/util/TestCgroupsLCEResourcesHandlerGPU.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/util/TestCgroupsLCEResourcesHandlerGPU.java
@@ -332,6 +332,8 @@ public class TestCgroupsLCEResourcesHandlerGPU {
     Device gpu3 = new Device(195, 3);
     Device gpu4 = new Device(195, 4);
     Device gpu5 = new Device(195, 5);
+    Device gpu6 = new Device(195, 6);
+    Device gpu7 = new Device(195, 7);
 
 
     // setup our handler and call init()
@@ -360,6 +362,8 @@ public class TestCgroupsLCEResourcesHandlerGPU {
     Assert.assertFalse(deniedDevices1.contains(gpu3));
     Assert.assertTrue(deniedDevices1.contains(gpu4));
     Assert.assertTrue(deniedDevices1.contains(gpu5));
+    Assert.assertTrue(deniedDevices1.contains(gpu6));
+    Assert.assertTrue(deniedDevices1.contains(gpu7));
 
     handler.postExecute(id);
 
@@ -373,6 +377,8 @@ public class TestCgroupsLCEResourcesHandlerGPU {
     Assert.assertTrue(deniedDevices2.contains(gpu3));
     Assert.assertTrue(deniedDevices2.contains(gpu4));
     Assert.assertTrue(deniedDevices2.contains(gpu5));
+    Assert.assertTrue(deniedDevices2.contains(gpu6));
+    Assert.assertTrue(deniedDevices2.contains(gpu7));
 
     FileUtils.deleteQuietly(cgroupDir);
   }


### PR DESCRIPTION
This is not ok to bypass the normal testing process.