### PR TITLE
HOPS-119

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsUtil.java
@@ -21,6 +21,7 @@ import com.google.common.io.ByteStreams;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.net.util.Base64;
@@ -32,6 +33,7 @@ import org.codehaus.jettison.json.JSONObject;
 import javax.ws.rs.core.MediaType;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 public class HopsUtil {
@@ -71,6 +73,25 @@ public class HopsUtil {
       String username, Configuration conf) throws JSONException, IOException {
     String keyStoreEncoded = keystoreEncode(keyStorePath);
     return getCertPassFromHwInternal(keyStoreEncoded, username, conf);
+  }
+  
+  /**
+   * Read password for cryptographic material from a file. The file could be
+   * either localized in a container or from Hopsworks certificates transient
+   * directory.
+   * @param passwdFile Location of the password file
+   * @return Password to unlock cryptographic material
+   * @throws IOException
+   */
+  public static String readCryptoMaterialPassword(File passwdFile) throws
+      IOException {
+    
+    if (!passwdFile.exists()) {
+      throw new FileNotFoundException("File containing crypto material " +
+          "password could not be found");
+    }
+    
+    return FileUtils.readFileToString(passwdFile);
   }
   
   private static String getCertPassFromHwInternal(String keyStoreEncoded,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CryptoMaterial.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CryptoMaterial.java
@@ -23,6 +23,7 @@ public class CryptoMaterial {
   private final String keyStoreLocation;
   private final int keyStoreSize;
   private final String trustStoreLocation;
+  private final String passwdLocation;
   private final int trustStoreSize;
   private final ByteBuffer keyStoreMem;
   private final String keyStorePass;
@@ -35,12 +36,13 @@ public class CryptoMaterial {
   private int requestedApplications;
   
   public CryptoMaterial(String keyStoreLocation, String trustStoreLocation,
-      ByteBuffer kStore, String kStorePass,
+      String passwdLocation, ByteBuffer kStore, String kStorePass,
       ByteBuffer tstore, String tstorePass) {
     this.keyStoreLocation = keyStoreLocation;
     this.keyStoreSize = kStore.capacity();
     this.trustStoreLocation = trustStoreLocation;
     this.trustStoreSize = tstore.capacity();
+    this.passwdLocation = passwdLocation;
     
     this.keyStoreMem = kStore.asReadOnlyBuffer();
     this.keyStorePass = kStorePass;
@@ -60,6 +62,10 @@ public class CryptoMaterial {
   
   public String getTrustStoreLocation() {
     return trustStoreLocation;
+  }
+  
+  public String getPasswdLocation() {
+    return passwdLocation;
   }
   
   public int getTrustStoreSize() {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/TestHopsSSLConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/TestHopsSSLConfiguration.java
@@ -19,6 +19,7 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
@@ -98,7 +99,10 @@ public class TestHopsSSLConfiguration {
         String kstore = touchFile("/tmp/project__user__kstore.jks");
         String tstore = touchFile("/tmp/project__user__tstore.jks");
         String password = "a_strong_password";
-        hopsFactory.setPaswordFromHopsworks(password);
+        Path passwdFile = Paths.get("/tmp", "project__user__cert.key");
+        touchFile(passwdFile.toString());
+        FileUtils.writeStringToFile(passwdFile.toFile(), password, false);
+        
         UserGroupInformation ugi = UserGroupInformation.createRemoteUser("project__user");
         final Set<String> superusers = new HashSet<>(1);
         superusers.add("superuser");
@@ -129,8 +133,10 @@ public class TestHopsSSLConfiguration {
         touchFile(Paths.get(cwd, "k_certificate").toString());
         touchFile(Paths.get(cwd, "t_certificate").toString());
         final String password = "a_strong_password";
-        
-        
+        Path passwdFile = Paths.get(cwd, "material_passwd");
+        touchFile(passwdFile.toString());
+        FileUtils.writeStringToFile(passwdFile.toFile(), password, false);
+    
         UserGroupInformation ugi = UserGroupInformation.createRemoteUser("project__user");
         final Set<String> superusers = new HashSet<>(1);
         superusers.add("superuser");
@@ -138,7 +144,6 @@ public class TestHopsSSLConfiguration {
             @Override
             public Object run() throws SSLCertificateException {
                 hopsFactory.setConf(conf);
-                hopsFactory.setPaswordFromHopsworks(password);
                 hopsFactory.configureCryptoMaterial(null, superusers);
                 return null;
             }
@@ -167,9 +172,12 @@ public class TestHopsSSLConfiguration {
             .toString();
         String tstore = Paths.get(tmp, "project__user__tstore.jks")
             .toString();
+        Path passwdFile = Paths.get(tmp, "project__user__cert.key");
         String password = "a_strong_password";
         touchFile(kstore);
         touchFile(tstore);
+        touchFile(passwdFile.toString());
+        FileUtils.writeStringToFile(passwdFile.toFile(), password, false);
         String hostname = NetUtils.getLocalHostname();
         String hKstore = Paths.get(tmp, hostname + "__kstore.jks")
             .toString();
@@ -182,7 +190,6 @@ public class TestHopsSSLConfiguration {
             .getValue(), "/tmp/" + hostname + "__kstore.jks");
         conf.set(HopsSSLSocketFactory.CryptoKeys.TRUST_STORE_FILEPATH_KEY
             .getValue(), "/tmp/" + hostname + "__tstore.jks");
-        hopsFactory.setPaswordFromHopsworks(password);
         UserGroupInformation ugi = UserGroupInformation
             .createRemoteUser("project__user");
         final Set<String> superusers = new HashSet<>(1);


### PR DESCRIPTION
[HOPS-119] Read crypto material password from file instead of making a REST call to Hopsworks

[HOPS-119] Inject password file in a container

[HOPS-119] Replace hardcoded strings

[HOPS-119] Remove unused imports

[HOPS-119] Put back correct name for localized password file

https://hopshadoop.atlassian.net/browse/HOPS-119