### PR TITLE
[HOPS-147] Reloading SSL key manager

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/conf/ssl-client.xml.example
+++ b/hadoop-common-project/hadoop-common/src/main/conf/ssl-client.xml.example
@@ -77,4 +77,19 @@
   </description>
 </property>
 
+<property>
+  <name>ssl.client.keystore.reload.interval</name>
+  <value>10000</value>
+  <description>Keystore reload check interval.
+  Check ssl.client.keystore.reload.timeunit for the time unit
+  </description>
+</property>
+
+<property>
+  <name>ssl.client.keystore.reload.timeunit</name>
+  <value>MILLISECONDS</value>
+  <description>Keystore reload check interval timeunit, accepts values of java.util.concurrent.TimeUnit
+  Default value is MILLISECONDS
+  </description>
+</property>
 </configuration>

--- a/hadoop-common-project/hadoop-common/src/main/conf/ssl-server.xml.example
+++ b/hadoop-common-project/hadoop-common/src/main/conf/ssl-server.xml.example
@@ -76,6 +76,22 @@
 </property>
 
 <property>
+  <name>ssl.server.keystore.reload.interval</name>
+  <value>10000</value>
+  <description>Keystore reload check interval.
+  Check ssl.client.keystore.reload.timeunit for the time unit
+  </description>
+</property>
+
+<property>
+  <name>ssl.server.keystore.reload.timeunit</name>
+  <value>MILLISECONDS</value>
+  <description>Keystore reload check interval timeunit, accepts values of java.util.concurrent.TimeUnit
+  Default value is MILLISECONDS
+  </description>
+</property>
+
+<property>
   <name>ssl.server.exclude.cipher.list</name>
   <value>TLS_ECDHE_RSA_WITH_RC4_128_SHA,SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA,
   SSL_RSA_WITH_DES_CBC_SHA,SSL_DHE_RSA_WITH_DES_CBC_SHA,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/FileBasedKeyStoresFactory.java
@@ -28,12 +28,11 @@ import org.apache.hadoop.util.StringUtils;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.text.MessageFormat;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link KeyStoresFactory} implementation that reads the certificates from
@@ -50,6 +49,10 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
   private static final Log LOG =
     LogFactory.getLog(FileBasedKeyStoresFactory.class);
 
+  public static final String SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY =
+      "ssl.{0}.keystore.reload.interval";
+  public static final String SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY =
+      "ssl.{0}.keystore.reload.timeunit";
   public static final String SSL_KEYSTORE_LOCATION_TPL_KEY =
     "ssl.{0}.keystore.location";
   public static final String SSL_KEYSTORE_PASSWORD_TPL_KEY =
@@ -79,9 +82,21 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
    * Reload interval in milliseconds.
    */
   public static final int DEFAULT_SSL_TRUSTSTORE_RELOAD_INTERVAL = 10000;
-
+  
+  /**
+   * Default keystore reload interval
+   * See also DEFAULT_SSL_KEYSTORE_RELOAD_TIMEUNIT
+   */
+  public static final long DEFAULT_SSL_KEYSTORE_RELOAD_INTERVAL = 10000;
+  
+  /**
+   * Default keystore reload interval time unit
+   */
+  public static final String DEFAULT_SSL_KEYSTORE_RELOAD_TIMEUNIT = "MILLISECONDS";
+  
   private Configuration conf;
   private KeyManager[] keyManagers;
+  private ReloadingX509KeyManager keyManager;
   private TrustManager[] trustManagers;
   private ReloadingX509TrustManager trustManager;
 
@@ -133,69 +148,80 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
   @Override
   public void init(SSLFactory.Mode mode)
     throws IOException, GeneralSecurityException {
+    // key store
+    createKeyManagers(mode);
 
+    // trust store
+    createTrustManagers(mode);
+  }
+  
+  private void createKeyManagers(SSLFactory.Mode mode) throws IOException, GeneralSecurityException {
     boolean requireClientCert =
-      conf.getBoolean(SSLFactory.SSL_REQUIRE_CLIENT_CERT_KEY,
-          SSLFactory.DEFAULT_SSL_REQUIRE_CLIENT_CERT);
-
-    // certificate store
+        conf.getBoolean(SSLFactory.SSL_REQUIRE_CLIENT_CERT_KEY,
+            SSLFactory.DEFAULT_SSL_REQUIRE_CLIENT_CERT);
+  
     String keystoreType =
-      conf.get(resolvePropertyName(mode, SSL_KEYSTORE_TYPE_TPL_KEY),
-               DEFAULT_KEYSTORE_TYPE);
-    KeyStore keystore = KeyStore.getInstance(keystoreType);
-    String keystoreKeyPassword = null;
+        conf.get(resolvePropertyName(mode, SSL_KEYSTORE_TYPE_TPL_KEY),
+            DEFAULT_KEYSTORE_TYPE);
+  
     if (requireClientCert || mode == SSLFactory.Mode.SERVER) {
       String locationProperty =
-        resolvePropertyName(mode, SSL_KEYSTORE_LOCATION_TPL_KEY);
+          resolvePropertyName(mode, SSL_KEYSTORE_LOCATION_TPL_KEY);
       String keystoreLocation = conf.get(locationProperty, "");
       if (keystoreLocation.isEmpty()) {
         throw new GeneralSecurityException("The property '" + locationProperty +
-          "' has not been set in the ssl configuration file.");
+            "' has not been set in the ssl configuration file.");
       }
       String passwordProperty =
-        resolvePropertyName(mode, SSL_KEYSTORE_PASSWORD_TPL_KEY);
+          resolvePropertyName(mode, SSL_KEYSTORE_PASSWORD_TPL_KEY);
       String keystorePassword = getPassword(conf, passwordProperty, "");
       if (keystorePassword.isEmpty()) {
         throw new GeneralSecurityException("The property '" + passwordProperty +
-          "' has not been set in the ssl configuration file.");
+            "' has not been set in the ssl configuration file.");
       }
       String keyPasswordProperty =
-        resolvePropertyName(mode, SSL_KEYSTORE_KEYPASSWORD_TPL_KEY);
+          resolvePropertyName(mode, SSL_KEYSTORE_KEYPASSWORD_TPL_KEY);
       // Key password defaults to the same value as store password for
       // compatibility with legacy configurations that did not use a separate
       // configuration property for key password.
-      keystoreKeyPassword = getPassword(
+      String keystoreKeyPassword = getPassword(
           conf, keyPasswordProperty, keystorePassword);
       if (LOG.isDebugEnabled()) {
         LOG.debug(mode.toString() + " KeyStore: " + keystoreLocation);
       }
-
-      InputStream is = new FileInputStream(keystoreLocation);
-      try {
-        keystore.load(is, keystorePassword.toCharArray());
-      } finally {
-        is.close();
-      }
+    
+      long keyStoreReloadInterval = conf.getLong(
+          resolvePropertyName(mode, SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY),
+              DEFAULT_SSL_KEYSTORE_RELOAD_INTERVAL);
+      String timeUnitStr = conf.get(
+          resolvePropertyName(mode, SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY),
+              DEFAULT_SSL_KEYSTORE_RELOAD_TIMEUNIT);
+      TimeUnit reloadTimeUnit = TimeUnit.valueOf(timeUnitStr.toUpperCase());
+      
+      keyManager = new ReloadingX509KeyManager(keystoreType, keystoreLocation, keystorePassword, keystoreKeyPassword,
+          keyStoreReloadInterval, reloadTimeUnit);
+      keyManager.init();
       if (LOG.isDebugEnabled()) {
         LOG.debug(mode.toString() + " Loaded KeyStore: " + keystoreLocation);
       }
+      keyManagers = new KeyManager[]{keyManager};
     } else {
-      keystore.load(null, null);
+      // Deal with it
+      KeyStore keyStore = KeyStore.getInstance(keystoreType);
+      keyStore.load(null, null);
+      KeyManagerFactory keyMgrFactory = KeyManagerFactory.getInstance(SSLFactory.SSLCERTIFICATE);
+      keyMgrFactory.init(keyStore, null);
+      keyManagers = keyMgrFactory.getKeyManagers();
     }
-    KeyManagerFactory keyMgrFactory = KeyManagerFactory
-        .getInstance(SSLFactory.SSLCERTIFICATE);
-      
-    keyMgrFactory.init(keystore, (keystoreKeyPassword != null) ?
-                                 keystoreKeyPassword.toCharArray() : null);
-    keyManagers = keyMgrFactory.getKeyManagers();
+  }
 
-    //trust store
+  private void createTrustManagers(SSLFactory.Mode mode) throws IOException, GeneralSecurityException {
     String truststoreType =
-      conf.get(resolvePropertyName(mode, SSL_TRUSTSTORE_TYPE_TPL_KEY),
-               DEFAULT_KEYSTORE_TYPE);
-
+        conf.get(resolvePropertyName(mode, SSL_TRUSTSTORE_TYPE_TPL_KEY),
+            DEFAULT_KEYSTORE_TYPE);
+  
     String locationProperty =
-      resolvePropertyName(mode, SSL_TRUSTSTORE_LOCATION_TPL_KEY);
+        resolvePropertyName(mode, SSL_TRUSTSTORE_LOCATION_TPL_KEY);
     String truststoreLocation = conf.get(locationProperty, "");
     if (!truststoreLocation.isEmpty()) {
       String passwordProperty = resolvePropertyName(mode,
@@ -209,11 +235,11 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
           conf.getLong(
               resolvePropertyName(mode, SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY),
               DEFAULT_SSL_TRUSTSTORE_RELOAD_INTERVAL);
-
+    
       if (LOG.isDebugEnabled()) {
         LOG.debug(mode.toString() + " TrustStore: " + truststoreLocation);
       }
-
+    
       trustManager = new ReloadingX509TrustManager(truststoreType,
           truststoreLocation,
           truststorePassword,
@@ -231,7 +257,7 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
       trustManagers = null;
     }
   }
-
+  
   String getPassword(Configuration conf, String alias, String defaultPass) {
     String password = defaultPass;
     try {
@@ -255,8 +281,13 @@ public class FileBasedKeyStoresFactory implements KeyStoresFactory {
     if (trustManager != null) {
       trustManager.destroy();
       trustManager = null;
-      keyManagers = null;
       trustManagers = null;
+    }
+    
+    if (keyManager != null) {
+      keyManager.stop();
+      keyManager = null;
+      keyManagers = null;
     }
   }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/ReloadingX509KeyManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/ReloadingX509KeyManager.java
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.security.ssl;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509KeyManager;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ReloadingX509KeyManager extends X509ExtendedKeyManager {
+  private final Log LOG = LogFactory.getLog(ReloadingX509KeyManager.class);
+  private final String type;
+  private final File location;
+  private final String keystorePassword;
+  private final String keyPassword;
+  private final long reloadInterval;
+  private final TimeUnit reloadTimeUnit;
+  private final ExecutorService exec;
+  
+  private AtomicReference<X509ExtendedKeyManager> keyManagerLocalRef;
+  private long lastLoadedTimestamp;
+  private Reloader reloader = null;
+  // For testing
+  private final AtomicBoolean fileExists = new AtomicBoolean(true);
+  
+  /**
+   * Creates a reloadable keystore manager.
+   *
+   * @param type type of the keystore, jks
+   * @param location path to keystore in the local file system
+   * @param keystorePassword password of the keystore
+   * @param keyPassword password of the key
+   * @param reloadInterval interval to check if the keystore has altered (ms)
+   */
+  public ReloadingX509KeyManager(String type, String location, String keystorePassword, String keyPassword,
+      long reloadInterval, TimeUnit reloadTimeUnit) throws GeneralSecurityException, IOException {
+    this.type = type;
+    this.location = new File(location);
+    this.keystorePassword = keystorePassword;
+    this.keyPassword = keyPassword;
+    this.reloadInterval = reloadInterval;
+    this.reloadTimeUnit = reloadTimeUnit;
+    keyManagerLocalRef = new AtomicReference<>(loadKeyManager());
+    exec = Executors.newSingleThreadExecutor();
+  }
+  
+  /**
+   * Starts the reloading thread
+   */
+  public void init() {
+    if (reloader == null) {
+      reloader = new Reloader();
+      exec.submit(reloader);
+    }
+  }
+  
+  /**
+   * Stops the reloading thread
+   */
+  public void stop() {
+    exec.shutdownNow();
+  }
+  
+  @VisibleForTesting
+  public long getReloadInterval() {
+    return reloadInterval;
+  }
+  
+  @VisibleForTesting
+  public TimeUnit getReloadTimeUnit() {
+    return reloadTimeUnit;
+  }
+  
+  @VisibleForTesting
+  public AtomicBoolean getFileExists() {
+    return fileExists;
+  }
+  
+  private boolean needsReload() {
+    if (location.exists()) {
+      if (location.lastModified() > lastLoadedTimestamp) {
+        return true;
+      }
+    } else {
+      fileExists.set(false);
+    }
+    
+    return false;
+  }
+  
+  @Override
+  public String[] getClientAliases(String s, Principal[] principals) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.getClientAliases(s, principals);
+    }
+    return null;
+  }
+  
+  @Override
+  public String chooseClientAlias(String[] strings, Principal[] principals, Socket socket) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.chooseClientAlias(strings, principals, socket);
+    }
+    return null;
+  }
+  
+  @Override
+  public String[] getServerAliases(String s, Principal[] principals) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.getServerAliases(s, principals);
+    }
+    return null;
+  }
+  
+  @Override
+  public String chooseServerAlias(String s, Principal[] principals, Socket socket) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.chooseServerAlias(s, principals, socket);
+    }
+    return null;
+  }
+  
+  @Override
+  public X509Certificate[] getCertificateChain(String s) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.getCertificateChain(s);
+    }
+    return null;
+  }
+  
+  @Override
+  public PrivateKey getPrivateKey(String s) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.getPrivateKey(s);
+    }
+    return null;
+  }
+  
+  @Override
+  public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.chooseEngineClientAlias(keyType, issuers, engine);
+    }
+    return null;
+  }
+  
+  @Override
+  public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+    X509ExtendedKeyManager km = keyManagerLocalRef.get();
+    if (km != null) {
+      return km.chooseEngineServerAlias(keyType, issuers, engine);
+    }
+    return null;
+  }
+  
+  private X509ExtendedKeyManager loadKeyManager() throws GeneralSecurityException, IOException {
+    KeyStore keyStore = KeyStore.getInstance(type);
+    try (FileInputStream in = new FileInputStream(location)) {
+      keyStore.load(in, keystorePassword.toCharArray());
+      lastLoadedTimestamp = location.lastModified();
+      LOG.debug("Loaded keystore file: " + location);
+    }
+    
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance(SSLFactory.SSLCERTIFICATE);
+    kmf.init(keyStore, keyPassword.toCharArray());
+    X509ExtendedKeyManager keyManager = null;
+    KeyManager[] keyManagers = kmf.getKeyManagers();
+    for (KeyManager km : keyManagers) {
+      if (km instanceof X509ExtendedKeyManager) {
+        keyManager = (X509ExtendedKeyManager) km;
+        break;
+      }
+    }
+    
+    return keyManager;
+  }
+  
+  private class Reloader implements Runnable {
+    @Override
+    public void run() {
+      while (!Thread.currentThread().isInterrupted()) {
+        try {
+          reloadTimeUnit.sleep(reloadInterval);
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+        }
+        
+        if (needsReload()) {
+          try {
+            keyManagerLocalRef.set(loadKeyManager());
+          } catch (GeneralSecurityException | IOException ex) {
+            LOG.error("Could not reload Key Manager. Using the previously loaded key store", ex);
+          }
+        }
+      }
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/KeyStoreTestUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/KeyStoreTestUtil.java
@@ -476,6 +476,10 @@ public class KeyStoreTestUtil {
         FileBasedKeyStoresFactory.SSL_KEYSTORE_KEYPASSWORD_TPL_KEY),
         keyPassword);
     }
+    sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
+        FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY), "1000");
+    sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
+        FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY), "MILLISECONDS");
     if (trustKS != null) {
       sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
         FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY), trustKS);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestReloadingX509KeyManager.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestReloadingX509KeyManager.java
@@ -1,0 +1,208 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.security.ssl;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class TestReloadingX509KeyManager {
+  private static final String BASE_DIR = GenericTestUtils
+      .getTempPath(TestReloadingX509KeyManager.class.getSimpleName());
+  private static final File baseDirFile = new File(BASE_DIR);
+  
+  private final Log LOG = LogFactory.getLog(TestReloadingX509KeyManager.class);
+  private final String KEY_PAIR_ALGORITHM = "RSA";
+  private final String CERTIFICATE_ALGORITHM = "SHA1withRSA";
+  private final String KEYSTORE_PASSWORD = "password";
+  
+  @Rule
+  public final ExpectedException rule = ExpectedException.none();
+  
+  @BeforeClass
+  public static void setUp() throws IOException {
+    FileUtils.deleteDirectory(baseDirFile);
+    baseDirFile.mkdirs();
+  }
+  
+  @AfterClass
+  public static void tearDown() throws IOException {
+    FileUtils.deleteDirectory(baseDirFile);
+  }
+  
+  @Test(timeout = 4000)
+  public void testReload() throws Exception {
+    KeyPair keyPair = KeyStoreTestUtil.generateKeyPair(KEY_PAIR_ALGORITHM);
+    X509Certificate cert1 = KeyStoreTestUtil.generateCertificate("CN=cert1", keyPair, 2, CERTIFICATE_ALGORITHM);
+    String keyStoreLocation = Paths.get(BASE_DIR, "testKeystore.jks").toString();
+    KeyStoreTestUtil.createKeyStore(keyStoreLocation, KEYSTORE_PASSWORD, "cert1", keyPair.getPrivate(), cert1);
+    
+    ReloadingX509KeyManager keyManager = new ReloadingX509KeyManager("jks", keyStoreLocation, KEYSTORE_PASSWORD,
+        KEYSTORE_PASSWORD, 10, TimeUnit.MILLISECONDS);
+    
+    try {
+      keyManager.init();
+  
+      TimeUnit reloadTimeUnit = keyManager.getReloadTimeUnit();
+      long reloadInterval = keyManager.getReloadInterval();
+      
+      X509Certificate[] certChain = keyManager.getCertificateChain("cert1");
+      assertNotNull("Certificate chain should not be null for alias cert1", certChain);
+      assertEquals("Certificate chain should be 1", 1, certChain.length);
+      assertEquals("DN for cert1 should be CN=cert1", cert1.getSubjectDN().getName(),
+          certChain[0].getSubjectDN().getName());
+      
+      // Wait a bit for the modification time to be different
+      reloadTimeUnit.sleep(reloadInterval);
+      TimeUnit.SECONDS.sleep(1);
+      
+      // Replace keystore with a new one with a different DN
+      X509Certificate cert2 = KeyStoreTestUtil.generateCertificate("CN=cert2", keyPair, 2, CERTIFICATE_ALGORITHM);
+      KeyStoreTestUtil.createKeyStore(keyStoreLocation, KEYSTORE_PASSWORD, "cert2", keyPair.getPrivate(), cert2);
+      
+      reloadTimeUnit.sleep(reloadInterval);
+      
+      certChain = keyManager.getCertificateChain("cert1");
+      assertNull("Certificate chain for alias cert1 should be null", certChain);
+      certChain = keyManager.getCertificateChain("cert2");
+      assertNotNull("Certificate chain should not be null for alias cert2", certChain);
+      assertEquals("Certificate chain should be 1", 1, certChain.length);
+      assertEquals("DN for cert2 should be CN=cert2", cert2.getSubjectDN().getName(),
+          certChain[0].getSubjectDN().getName());
+      
+    } finally {
+      keyManager.stop();
+    }
+  }
+  
+  @Test
+  public void testLoadMissingKeyStore() throws Exception {
+    String keyStoreLocation = Paths.get(BASE_DIR, "testKeystore.jks").toString();
+    
+    rule.expect(IOException.class);
+    ReloadingX509KeyManager keyManager = new ReloadingX509KeyManager("jks", keyStoreLocation, "", "", 10,
+        TimeUnit.MILLISECONDS);
+    try {
+      keyManager.init();
+    } finally {
+      keyManager.stop();
+    }
+  }
+  
+  @Test
+  public void testLoadCorruptedKeyStore() throws Exception {
+    String keyStoreLocation = Paths.get(BASE_DIR, "corrupterTestKeystore.jks").toString();
+    FileOutputStream outputStream = new FileOutputStream(keyStoreLocation);
+    outputStream.write("something".getBytes());
+    outputStream.close();
+    
+    rule.expect(IOException.class);
+    rule.expectMessage("Invalid keystore format");
+    ReloadingX509KeyManager keyManager = new ReloadingX509KeyManager("jks", keyStoreLocation, "", "", 10,
+        TimeUnit.MILLISECONDS);
+    try {
+      keyManager.init();
+    } finally {
+      keyManager.stop();
+    }
+  }
+  
+  @Test(timeout = 4000)
+  public void testReloadMissingKeyStore() throws Exception {
+    KeyPair keyPair = KeyStoreTestUtil.generateKeyPair(KEY_PAIR_ALGORITHM);
+    X509Certificate cert = KeyStoreTestUtil.generateCertificate("CN=cert", keyPair, 2, CERTIFICATE_ALGORITHM);
+    String keyStoreLocation = Paths.get(BASE_DIR, "testKeystore.jks").toString();
+    KeyStoreTestUtil.createKeyStore(keyStoreLocation, KEYSTORE_PASSWORD, "cert", keyPair.getPrivate(), cert);
+    
+    ReloadingX509KeyManager keyManager = new ReloadingX509KeyManager("jks", keyStoreLocation, KEYSTORE_PASSWORD,
+        KEYSTORE_PASSWORD, 10, TimeUnit.MILLISECONDS);
+    try {
+      keyManager.init();
+      X509Certificate[] certChain = keyManager.getCertificateChain("cert");
+      assertNotNull("Certificate chain should not be null for alias cert", certChain);
+      
+      // Delete the keystore
+      FileUtils.forceDelete(new File(keyStoreLocation));
+      
+      keyManager.getReloadTimeUnit().sleep(keyManager.getReloadInterval());
+      TimeUnit.SECONDS.sleep(1);
+  
+      AtomicBoolean fileExists = keyManager.getFileExists();
+      assertFalse("Key manager should detect file does not exist", fileExists.get());
+      
+      certChain = keyManager.getCertificateChain("cert");
+      assertNotNull("Certificate chain should not be null for alias cert", certChain);
+    } finally {
+      keyManager.stop();
+    }
+  }
+  
+  @Test(timeout = 4000)
+  public void testReloadCorruptedKeyStore() throws Exception {
+    KeyPair keyPair = KeyStoreTestUtil.generateKeyPair(KEY_PAIR_ALGORITHM);
+    X509Certificate cert = KeyStoreTestUtil.generateCertificate("CN=cert", keyPair, 2, CERTIFICATE_ALGORITHM);
+    String keyStoreLocation = Paths.get(BASE_DIR, "testKeystore.jks").toString();
+    KeyStoreTestUtil.createKeyStore(keyStoreLocation, KEYSTORE_PASSWORD, "cert", keyPair.getPrivate(), cert);
+    
+    ReloadingX509KeyManager keyManager = new ReloadingX509KeyManager("jks", keyStoreLocation, KEYSTORE_PASSWORD,
+        KEYSTORE_PASSWORD, 10, TimeUnit.MILLISECONDS);
+    
+    try {
+      keyManager.init();
+      X509Certificate[] certChain = keyManager.getCertificateChain("cert");
+      assertNotNull("Certificate chain should not be null for alias cert", certChain);
+      
+      keyManager.getReloadTimeUnit().sleep(keyManager.getReloadInterval());
+      TimeUnit.SECONDS.sleep(1);
+      
+      FileOutputStream outputStream = new FileOutputStream(keyStoreLocation);
+      outputStream.write("something".getBytes());
+      outputStream.close();
+  
+      keyManager.getReloadTimeUnit().sleep(keyManager.getReloadInterval());
+      TimeUnit.SECONDS.sleep(1);
+  
+      certChain = keyManager.getCertificateChain("cert");
+      assertNotNull("Certificate chain should not be null for alias cert", certChain);
+      assertEquals("DN for cert should be CN=cert", cert.getSubjectDN().getName(),
+          certChain[0].getSubjectDN().getName());
+    } finally {
+      keyManager.stop();
+    }
+  }
+}

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/EncryptedShuffle.md
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/site/markdown/EncryptedShuffle.md
@@ -122,6 +122,8 @@ The mapred user should own the **ssl-server.xml** file and have exclusive read a
 | `ssl.server.keystore.type` | `jks` | Keystore file type |
 | `ssl.server.keystore.location` | NONE | Keystore file location. The mapred user should own this file and have exclusive read access to it. |
 | `ssl.server.keystore.password` | NONE | Keystore file password |
+| `ssl.server.keystore.reload.timeunit` | MILLISECONDS | Keystore reload interval time unit `java.util.concurrent.Timeunit` |
+| `ssl.server.keystore.reload.interval` | 10000 | Keystore reload interval, in TimeUnits defined by `ssl.server.keystore.reload.timeunit` |
 | `ssl.server.truststore.type` | `jks` | Truststore file type |
 | `ssl.server.truststore.location` | NONE | Truststore file location. The mapred user should own this file and have exclusive read access to it. |
 | `ssl.server.truststore.password` | NONE | Truststore file password |
@@ -144,6 +146,14 @@ The mapred user should own the **ssl-server.xml** file and have exclusive read a
   <property>
     <name>ssl.server.keystore.password</name>
     <value>serverfoo</value>
+  </property>
+  <property>
+    <name>ssl.server.keystore.reload.timeunit</name>
+    <value>MILLISECONDS</value>
+  </property>
+  <property>
+    <name>ssl.server.keystore.reload.interval</name>
+    <value>10000</value>
   </property>
 
   <!-- Server Trust Store -->
@@ -175,6 +185,8 @@ The mapred user should own the **ssl-client.xml** file and it should have defaul
 | `ssl.client.keystore.type` | `jks` | Keystore file type |
 | `ssl.client.keystore.location` | NONE | Keystore file location. The mapred user should own this file and it should have default permissions. |
 | `ssl.client.keystore.password` | NONE | Keystore file password |
+| `ssl.client.keystore.reload.timeunit` | MILLISECONDS | Keystore reload interval time unit `java.util.concurrent.Timeunit` |
+| `ssl.client.keystore.reload.interval` | 10000 | Keystore reload interval, in TimeUnits defined by `ssl.server.keystore.reload.timeunit` |
 | `ssl.client.truststore.type` | `jks` | Truststore file type |
 | `ssl.client.truststore.location` | NONE | Truststore file location. The mapred user should own this file and it should have default permissions. |
 | `ssl.client.truststore.password` | NONE | Truststore file password |
@@ -197,6 +209,14 @@ The mapred user should own the **ssl-client.xml** file and it should have defaul
   <property>
     <name>ssl.client.keystore.password</name>
     <value>clientfoo</value>
+  </property>
+  <property>
+    <name>ssl.client.keystore.reload.timeunit</name>
+    <value>MILLISECONDS</value>
+  </property>
+  <property>
+    <name>ssl.client.keystore.reload.interval</name>
+    <value>10000</value>
   </property>
 
   <!-- Client Trust Store -->


### PR DESCRIPTION
[HOPS-147]  Implement a basic keystore manager

[HOPS-147]  Reloading thread

[HOPS-147]  Basic reloading testing for the key manager

[HOPS-147]  Test key manager when keystore is missing or corrupted

[HOPS-147]  Add more tests for reloading keystore manager

[HOPS-147]  Refactor key store factory to support reloadable key manager

[HOPS-147]  Add documentation

[HOPS-147]  Remove unused imports

https://hopshadoop.atlassian.net/browse/HOPS-147