### PR TITLE
[HOPS-153] Configure TLS REST API for NameNode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -68,6 +68,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_HTTPS_ENABLE_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_DEFAULT;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_NAMENODE_KEYTAB_FILE_KEY;
@@ -1177,11 +1178,18 @@ public class NameNode {
               rpcServer.getServiceRpcAddress().getPort();
     }
 
+    String httpAddress;
+    if (conf.getBoolean(DFSConfigKeys.DFS_HTTPS_ENABLE_KEY, DFS_HTTPS_ENABLE_DEFAULT)) {
+      httpAddress = httpServer.getHttpAddress().getAddress().getHostAddress() + ":" + conf.getInt(DFSConfigKeys
+          .DFS_HTTPS_PORT_KEY, DFSConfigKeys.DFS_NAMENODE_HTTPS_PORT_DEFAULT);
+    } else {
+      httpAddress = httpServer.getHttpAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpAddress()
+          .getPort() ;
+    }
+    
     leaderElection =
         new LeaderElection(new HdfsLeDescriptorFactory(), leadercheckInterval,
-            missedHeartBeatThreshold, leIncrement,
-            httpServer.getHttpAddress().getAddress().getHostAddress() + ":" +
-                httpServer.getHttpAddress().getPort(),
+            missedHeartBeatThreshold, leIncrement, httpAddress,
             rpcAddresses);
     leaderElection.start();
 


### PR DESCRIPTION
[HOPS-153] Take the HTTPS NameNode info port if SSL is enabled
[HOPS-153]  Register to leader election protocol with the correct http port

[HOPS-153]  Remove hard-code url scheme