### PR TITLE
[HOPS-186] CryptoMaterial buffers should be available for re-reading

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CryptoMaterial.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CryptoMaterial.java
@@ -46,9 +46,9 @@ public class CryptoMaterial {
     this.trustStoreSize = tstore.capacity();
     this.passwdLocation = passwdLocation;
     
-    this.keyStoreMem = kStore.asReadOnlyBuffer();
+    this.keyStoreMem = kStore;
     this.keyStorePass = kStorePass;
-    this.trustStoreMem = tstore.asReadOnlyBuffer();
+    this.trustStoreMem = tstore;
     this.trustStorePass = tstorePass;
     
     requestedApplications = 1;
@@ -77,7 +77,7 @@ public class CryptoMaterial {
   }
   
   public ByteBuffer getKeyStoreMem() {
-    return keyStoreMem;
+    return keyStoreMem.asReadOnlyBuffer();
   }
   
   public String getKeyStorePass() {
@@ -85,7 +85,7 @@ public class CryptoMaterial {
   }
   
   public ByteBuffer getTrustStoreMem() {
-    return trustStoreMem;
+    return trustStoreMem.asReadOnlyBuffer();
   }
   
   public String getTrustStorePass() {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/security/CertificateLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/main/java/org/apache/hadoop/yarn/server/security/CertificateLocalizationService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.yarn.server.security;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.Server;
@@ -77,6 +78,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.locks.ReentrantLock;
 
+@InterfaceAudience.LimitedPrivate({"Hive"})
 public class CertificateLocalizationService extends AbstractService
     implements CertificateLocalization, CertificateLocalizationProtocol, CertificateLocalizationMBean {
   
@@ -116,7 +118,9 @@ public class CertificateLocalizationService extends AbstractService
 
   public enum ServiceType {
     RM("RM"),
-    NM("NM");
+    NM("NM"),
+    HS2("HS2"),
+    HM("HM");
 
     private final String service;
 
@@ -600,10 +604,12 @@ public class CertificateLocalizationService extends AbstractService
       FileChannel kstoreChannel = new FileOutputStream(kStorePath.toFile(), false)
           .getChannel();
       kstoreChannel.write(kstore);
+      kstore.rewind(); // Set the position to 0 so other clients can read the buffer later on
       kstoreChannel.close();
       FileChannel tstoreChannel = new FileOutputStream(tStorePath.toFile(), false)
           .getChannel();
       tstoreChannel.write(tstore);
+      tstore.rewind(); // Set the position to 0 so other clients can read the buffer later on
       tstoreChannel.close();
       FileUtils.writeStringToFile(passwdPath.toFile(), kstorePass);
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/security/TestCertificateLocalizationService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-common/src/test/java/org/apache/hadoop/yarn/server/security/TestCertificateLocalizationService.java
@@ -274,7 +274,34 @@ public class TestCertificateLocalizationService {
     TimeUnit.MILLISECONDS.sleep(10);
     verifyMaterialExistOrNot(certLocSrv, username, userFolder, keyStorePass, trustStorePass, false);
   }
-  
+
+  @Test
+  public void testMultipleReadsCryptoBuffers() throws Exception {
+    byte[] randomK = "Some_random_keystore_stuff".getBytes();
+    byte[] randomT = "Some_random_truststore_stuff".getBytes();
+    ByteBuffer bfk = ByteBuffer.wrap(randomK);
+    ByteBuffer bft = ByteBuffer.wrap(randomT);
+    String username = "Dr.Who";
+    String userFolder = "userfolder";
+    String keyStorePass = "keyStorePass";
+    String trustStorePass = "trustStorePass";
+
+    materializeCertificateUtil(certLocSrv, username, userFolder, bfk, keyStorePass, bft, trustStorePass);
+    CryptoMaterial cryptoMaterial = certLocSrv.getMaterialLocation(username);
+
+    assertTrue(bfk.equals(cryptoMaterial.getKeyStoreMem()));
+    assertTrue(bft.equals(cryptoMaterial.getTrustStoreMem()));
+
+    // Read twice to make sure reads are idempotent
+    assertTrue(bfk.equals(cryptoMaterial.getKeyStoreMem()));
+    assertTrue(bft.equals(cryptoMaterial.getTrustStoreMem()));
+
+    // Cleanup
+    certLocSrv.removeMaterial(username);
+  }
+
+
+
   @Test
   public void testMaterializationWithMultipleApplications() throws Exception {
     byte[] randomK = "Some_random_keystore_stuff".getBytes();


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-186


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the new behavior (if this is a feature change)?**
See jira


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**: