### PR TITLE
[HOPS-185] do not reserve GPU containers on CPU machines

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/allocator/RegularContainerAllocator.java
@@ -437,6 +437,11 @@ public class RegularContainerAllocator extends AbstractContainerAllocator {
           + " node total capability : " + node.getTotalResource());
       // Skip this locality request
       return ContainerAllocation.LOCALITY_SKIPPED;
+    } else if(node.getTotalResource().getGPUs() < capability.getGPUs()) {
+      LOG.warn("Node : " + node.getNodeID()
+              + " does not have sufficient resource for request : " + request
+              + " node total capability : " + node.getTotalResource());
+      return ContainerAllocation.LOCALITY_SKIPPED;
     }
 
     boolean shouldAllocOrReserveNewContainer = shouldAllocOrReserveNewContainer(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockAM.java
@@ -144,6 +144,10 @@ public class MockAM {
     requests.addAll(createReq(hosts, memory, priority, containers));
   }
 
+  public List<ResourceRequest> getRequests() {
+    return requests;
+  }
+
   public AllocateResponse schedule() throws Exception {
     AllocateResponse response = allocate(requests, releases);
     requests.clear();


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**

https://hopshadoop.atlassian.net/browse/HOPS-185


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This makes it not possible for a container requiring 1 or more GPUs to reserve resources on a machine without GPUs

* **What is the new behavior (if this is a feature change)?**

Skip container assignment if a node does not that GPUs.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: