### PR TITLE
[HOPS-258]  Change default TLS enabled protocols

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/HopsSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/HopsSSLSocketFactory.java
@@ -60,7 +60,7 @@ public class HopsSSLSocketFactory extends SocketFactory implements Configurable 
   private static final String KEY_PASSWORD_DEFAULT = "";
   private static final String TRUST_STORE_FILEPATH_DEFAULT = "client.truststore.jks";
   private static final String TRUST_STORE_PASSWORD_DEFAULT = "";
-  private static final String SOCKET_ENABLED_PROTOCOL_DEFAULT = "TLSv1";
+  private static final String SOCKET_ENABLED_PROTOCOL_DEFAULT = "TLSv1.2";
   
   public static final String LOCALIZED_PASSWD_FILE_NAME = "material_passwd";
   public static final String LOCALIZED_KEYSTORE_FILE_NAME = "k_certificate";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLFactory.java
@@ -79,7 +79,7 @@ public class SSLFactory implements ConnectionConfigurator {
 
   public static final String SSL_ENABLED_PROTOCOLS =
       "hadoop.ssl.enabled.protocols";
-  public static final String DEFAULT_SSL_ENABLED_PROTOCOLS = "TLSv1";
+  public static final String DEFAULT_SSL_ENABLED_PROTOCOLS = "TLSv1.2,TLSv1.1";
   public static final String SSL_SERVER_EXCLUDE_CIPHER_LIST =
       "ssl.server.exclude.cipher.list";
 

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/HopsSSLTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/HopsSSLTestUtils.java
@@ -102,7 +102,7 @@ public class HopsSSLTestUtils {
         conf.set(CommonConfigurationKeysPublic.HADOOP_RPC_SOCKET_FACTORY_CLASS_DEFAULT_KEY,
                 "org.apache.hadoop.net.HopsSSLSocketFactory");
         conf.setBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED, true);
-        conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS, "TLSv1.2,TLSv1.1,TLSv1");
+        conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS, "TLSv1.2,TLSv1.1");
         conf.set(SSLFactory.SSL_HOSTNAME_VERIFIER_KEY, "ALLOW_ALL");
         String user = UserGroupInformation.getCurrentUser().getUserName();
         conf.set(ProxyUsers.CONF_HADOOP_PROXYUSER + "." + user, "*");
@@ -121,7 +121,7 @@ public class HopsSSLTestUtils {
         conf.set(HopsSSLSocketFactory.CryptoKeys.TRUST_STORE_FILEPATH_KEY.getValue(), c_clientTrustStore.toString());
         conf.set(HopsSSLSocketFactory.CryptoKeys.TRUST_STORE_PASSWORD_KEY.getValue(), passwd);
         conf.set(HopsSSLSocketFactory.CryptoKeys.SOCKET_ENABLED_PROTOCOL
-            .getValue(), "TLSv1.1");
+            .getValue(), "TLSv1.2");
     }
 
     protected List<Path> prepareCryptoMaterial(Configuration conf, String outDir) throws Exception {


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-258

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove unsupported TLS/SSL versions and upgrade default TLS version for the client to TLSv1.2

* **What is the new behavior (if this is a feature change)?**
No new behaviour

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

* **Other information**: