### PR TITLE
[HOPS-337] fix replication index being stuck in UnderReplicatedBlocks

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderReplicatedBlocks.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/UnderReplicatedBlocks.java
@@ -402,7 +402,7 @@ class UnderReplicatedBlocks implements Iterable<Block> {
       blockCount += blks.size();
       replIndex += blks.size();
       
-      if (count(priority) <= remainingblksToProcess && priority == LEVEL - 1) {
+      if (priority == LEVEL - 1 && count(priority) <= replIndex) {
         // reset all priorities replication index to 0 because there is no
         // recently added blocks in any list.
         for (int i = 0; i < LEVEL; i++) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicy.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestReplicationPolicy.java
@@ -973,6 +973,19 @@ public class TestReplicationPolicy {
     // QUEUE_HIGHEST_PRIORITY, 1 block from QUEUE_VERY_UNDER_REPLICATED.
     chosenBlocks = underReplicatedBlocks.chooseUnderReplicatedBlocks(7);
     assertTheChosenBlocks(chosenBlocks, 6, 1, 0, 0, 0);
+
+    //choose all the remaining blocks except one to reach the end of the lists 
+    chosenBlocks = underReplicatedBlocks.chooseUnderReplicatedBlocks(18);
+    assertTheChosenBlocks(chosenBlocks, 0, 4, 5, 5, 4);
+    
+    //choose the last block in the lists, should set the system to restart picking the blocks
+    //from the start at next try
+    chosenBlocks = underReplicatedBlocks.chooseUnderReplicatedBlocks(1);
+    assertTheChosenBlocks(chosenBlocks, 0, 0, 0, 0, 1);
+    
+    //should start picking the blocks from start
+    chosenBlocks = underReplicatedBlocks.chooseUnderReplicatedBlocks(1);
+    assertTheChosenBlocks(chosenBlocks, 1, 0, 0, 0, 0);
   }
 
   /**


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-337

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: