### PR TITLE
[HOPS-453]  Fix bug with Hops group checker which wasn't falling back…

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsGroupsWithFallBack.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsGroupsWithFallBack.java
@@ -27,8 +27,9 @@ public class HopsGroupsWithFallBack extends
   public List<String> getGroups(final String user) throws IOException {
     List<String> groups = UsersGroups.getGroups(user);
 
-    if(groups != null)
+    if (groups != null && !groups.isEmpty()) {
       return groups;
+    }
 
     return super.getGroups(user);
   }


### PR DESCRIPTION
… to Unix groups

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-453

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
Hops group checker wasn't falling back to Unix groups if user existed in DB but not its groups

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change

* **Other information**: