### PR TITLE
[HOPS-458] SubTree operation on a large directory with millions of immediate children can kill the database.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/adaptor/INodeDALAdaptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/adaptor/INodeDALAdaptor.java
@@ -22,6 +22,7 @@ import io.hops.metadata.hdfs.entity.INode;
 import io.hops.metadata.hdfs.entity.INodeIdentifier;
 import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.metadata.hdfs.entity.ProjectedINode;
+import io.hops.transaction.context.EntityContext;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.permission.PermissionStatus;
 import org.apache.hadoop.hdfs.DFSUtil;
@@ -76,21 +77,28 @@ public class INodeDALAdaptor
   }
 
   @Override
-  public List<ProjectedINode> findInodesForSubtreeOperationsWithWriteLockPPIS(
-          int parentId, int partitionId) throws StorageException {
+  public List<ProjectedINode> findInodesPPISTx(
+          int parentId, int partitionId, EntityContext.LockMode lock) throws StorageException {
     List<ProjectedINode> list =
-            dataAccess.findInodesForSubtreeOperationsWithWriteLockPPIS(parentId, partitionId);
+            dataAccess.findInodesPPISTx(parentId, partitionId, lock);
     Collections.sort(list);
     return list;
   }
 
   @Override
-  public List<ProjectedINode> findInodesForSubtreeOperationsWithWriteLockFTIS(
-      int parentId) throws StorageException {
+  public List<ProjectedINode> findInodesFTISTx(
+      int parentId, EntityContext.LockMode lock) throws StorageException {
     List<ProjectedINode> list =
-        dataAccess.findInodesForSubtreeOperationsWithWriteLockFTIS(parentId);
+        dataAccess.findInodesFTISTx(parentId, lock);
     Collections.sort(list);
     return list;
+  }
+
+  public List<org.apache.hadoop.hdfs.server.namenode.INode> lockInodesUsingPkBatchTx(
+          String[] names, int[] parentIds, int[] partitionIds, EntityContext.LockMode lock)
+          throws StorageException {
+    return (List<org.apache.hadoop.hdfs.server.namenode.INode>) convertDALtoHDFS(
+            dataAccess.lockInodesUsingPkBatchTx(names, parentIds, partitionIds, lock));
   }
 
   @Override


### PR DESCRIPTION
[Hops-458] SubTree operation on a large directory with millions of immediate children can kill the database.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-458

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nay

* **Other information**:
hopshadoop/hops-metadata-dal#114 and hopshadoop/hops-metadata-dal-impl-ndb#140