### PR TITLE
[HOPS-550] Fix Unsetting MetaEnabled for a subtree

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -1855,10 +1855,10 @@ public class FSNamesystem
   void setMetaEnabled(final String src, final boolean metaEnabled)
       throws IOException {
     try {
-      INodeIdentifier inode = lockSubtree(src, SubTreeOperation.StoOperationType.META_ENABLE);
-      final AbstractFileTree.FileTree fileTree = new AbstractFileTree.FileTree(
-          FSNamesystem.this, inode);
-      fileTree.buildUp();
+      INodeIdentifier inode = lockSubtree(src, SubTreeOperation
+          .StoOperationType.META_ENABLE);
+      final AbstractFileTree.FileTree fileTree = buildTreeForLogging(inode,
+          metaEnabled);
       new HopsTransactionalRequestHandler(HDFSOperationType.SET_META_ENABLED,
           src) {
         @Override
@@ -1872,7 +1872,9 @@ public class FSNamesystem
         @Override
         public Object performTask() throws IOException {
           try {
-            logMetadataEvents(fileTree, MetadataLogEntry.Operation.ADD);
+            if(metaEnabled) {
+              logMetadataEvents(fileTree, MetadataLogEntry.Operation.ADD);
+            }
             setMetaEnabledInt(src, metaEnabled);
           } catch (AccessControlException e) {
             logAuditEvent(false, "setMetaEnabled", src);
@@ -1886,6 +1888,17 @@ public class FSNamesystem
     }
   }
 
+  private AbstractFileTree.FileTree buildTreeForLogging(INodeIdentifier
+      inode, boolean metaEnabled) throws IOException {
+    if(!metaEnabled)
+      return null;
+    
+    final AbstractFileTree.FileTree fileTree = new AbstractFileTree.FileTree(
+        FSNamesystem.this, inode);
+    fileTree.buildUp();
+    return fileTree;
+  }
+  
   private void setMetaEnabledInt(final String src, final boolean metaEnabled)
       throws IOException {
     FSPermissionChecker pc = getPermissionChecker();


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-550

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
Unsetting the MetaEnabled for a subtree won't write log entries to hdfs_metadata_log

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: