### PR TITLE
[HOPS-624]  Use the StandardSocketFactory in BlockReader when Hops TLS enabled

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -86,6 +86,8 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.hadoop.net.StandardSocketFactory;
 import org.apache.hadoop.util.Daemon;
 
 import javax.net.SocketFactory;
@@ -2902,14 +2904,19 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
   public ClientContext getClientContext() {
     return clientContext;
   }
-
+  
+  @Override // RemotePeerFactory
+  public SocketFactory getSocketFactory(Configuration conf) {
+    return new StandardSocketFactory();
+  }
+  
   @Override // RemotePeerFactory
   public Peer newConnectedPeer(InetSocketAddress addr) throws IOException {
     Peer peer = null;
     boolean success = false;
     Socket sock = null;
     try {
-      sock = socketFactory.createSocket();
+      sock = getSocketFactory(conf).createSocket();
       NetUtils.connect(sock, addr,
               getRandomLocalInterfaceAddr(),
               dfsClientConf.socketTimeout);
@@ -2924,7 +2931,7 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
       }
     }
   }
-
+  
   /**
    * Create hedged reads thread pool, HEDGED_READ_THREAD_POOL, if
    * it does not already exist.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/RemotePeerFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/RemotePeerFactory.java
@@ -20,16 +20,27 @@ package org.apache.hadoop.hdfs;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.net.Peer;
+
+import javax.net.SocketFactory;
 
 public interface RemotePeerFactory {
   /**
    * @param addr          The address to connect to.
-   * 
+   *
    * @return              A new Peer connected to the address.
    *
    * @throws IOException  If there was an error connecting or creating 
    *                      the remote socket, encrypted stream, etc.
    */
   Peer newConnectedPeer(InetSocketAddress addr) throws IOException;
+  
+  /**
+   * SocketFactory to be used to establish the connection
+   * @param conf
+   * @return appropriate socket factory
+   * @throws IOException
+   */
+  SocketFactory getSocketFactory(Configuration conf) throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/common/JspHelper.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.net.SocketFactory;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspWriter;
@@ -62,6 +63,7 @@ import org.apache.hadoop.hdfs.web.resources.DoAsParam;
 import org.apache.hadoop.hdfs.web.resources.UserParam;
 import org.apache.hadoop.http.HtmlQuoting;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.net.StandardSocketFactory;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -211,7 +213,7 @@ public class JspHelper {
     int index = doRandom ? DFSUtil.getRandom().nextInt(l) : 0;
     return nodes[index];
   }
-
+  
   public static void streamBlockInAscii(InetSocketAddress addr, String poolId,
       long blockId, Token<BlockTokenIdentifier> blockToken, long genStamp,
       long blockSize, long offsetIntoBlock, long chunkSizeToView, 
@@ -239,11 +241,17 @@ public class JspHelper {
       setCachingStrategy(CachingStrategy.newDefaultStrategy()).
       setConfiguration(conf).
       setRemotePeerFactory(new RemotePeerFactory() {
+        
+        @Override
+        public SocketFactory getSocketFactory(Configuration conf) throws IOException {
+          return new StandardSocketFactory();
+        }
+  
         @Override
         public Peer newConnectedPeer(InetSocketAddress addr)
             throws IOException {
           Peer peer = null;
-          Socket sock = NetUtils.getDefaultSocketFactory(conf).createSocket();
+          Socket sock = getSocketFactory(conf).createSocket();
           try {
             sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
             sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.NodeBase;
+import org.apache.hadoop.net.StandardSocketFactory;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
@@ -71,6 +72,8 @@ import org.apache.hadoop.hdfs.net.Peer;
 import org.apache.hadoop.hdfs.net.TcpPeerServer;
 import org.apache.hadoop.hdfs.server.blockmanagement.NumberReplicas;
 import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
+
+import javax.net.SocketFactory;
 
 /**
  * This class provides rudimentary checking of DFS volumes for errors and
@@ -614,7 +617,7 @@ public class NamenodeFsck {
       dfs.close();
     }
   }
-
+  
   /*
    * XXX (ab) Bulk of this method is copied verbatim from {@link DFSClient}, which is
    * bad. Both places should be refactored to provide a method to copy blocks
@@ -666,10 +669,15 @@ public class NamenodeFsck {
             setConfiguration(namenode.conf).
             setRemotePeerFactory(new RemotePeerFactory() {
               @Override
+              public SocketFactory getSocketFactory(Configuration conf) throws IOException {
+                return new StandardSocketFactory();
+              }
+  
+              @Override
               public Peer newConnectedPeer(InetSocketAddress addr)
                   throws IOException {
                 Peer peer = null;
-                Socket s = NetUtils.getDefaultSocketFactory(conf).createSocket();
+                Socket s = getSocketFactory(namenode.conf).createSocket();
                 try {
                   s.connect(addr, HdfsServerConstants.READ_TIMEOUT);
                   s.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BlockReaderTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BlockReaderTestUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdfs;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -50,6 +51,8 @@ import org.apache.hadoop.hdfs.server.namenode.CacheManager;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
+
+import javax.net.SocketFactory;
 
 /**
  * A helper class to setup the cluster, and get to BlockReader and DataNode for a block.
@@ -192,11 +195,15 @@ public class BlockReaderTestUtil {
       setAllowShortCircuitLocalReads(true).
       setRemotePeerFactory(new RemotePeerFactory() {
         @Override
+        public SocketFactory getSocketFactory(Configuration conf) throws IOException {
+          return NetUtils.getDefaultSocketFactory(conf);
+        }
+  
+        @Override
         public Peer newConnectedPeer(InetSocketAddress addr)
             throws IOException {
           Peer peer = null;
-          Socket sock = NetUtils.
-              getDefaultSocketFactory(fs.getConf()).createSocket();
+          Socket sock = getSocketFactory(fs.getConf()).createSocket();
           try {
             sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
             sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
@@ -60,6 +60,8 @@ import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
 import org.apache.hadoop.io.IOUtils;
 import org.junit.Assert;
 
+import javax.net.SocketFactory;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -162,10 +164,15 @@ public class TestBlockTokenWithDFS {
           setConfiguration(conf).
           setRemotePeerFactory(new RemotePeerFactory() {
             @Override
+            public SocketFactory getSocketFactory(Configuration conf) throws IOException {
+              return NetUtils.getDefaultSocketFactory(conf);
+            }
+  
+            @Override
             public Peer newConnectedPeer(InetSocketAddress addr)
                 throws IOException {
               Peer peer = null;
-              Socket sock = NetUtils.getDefaultSocketFactory(conf).createSocket();
+              Socket sock = getSocketFactory(conf).createSocket();
               try {
                 sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
                 sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailure.java
@@ -59,6 +59,8 @@ import org.apache.hadoop.hdfs.net.TcpPeerServer;
 import org.apache.hadoop.hdfs.server.protocol.BlockReport;
 import org.apache.hadoop.io.IOUtils;
 
+import javax.net.SocketFactory;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -364,10 +366,15 @@ public class TestDataNodeVolumeFailure {
       setConfiguration(conf).
       setRemotePeerFactory(new RemotePeerFactory() {
         @Override
+        public SocketFactory getSocketFactory(Configuration conf) throws IOException {
+          return NetUtils.getDefaultSocketFactory(conf);
+        }
+  
+        @Override
         public Peer newConnectedPeer(InetSocketAddress addr)
             throws IOException {
           Peer peer = null;
-          Socket sock = NetUtils.getDefaultSocketFactory(conf).createSocket();
+          Socket sock = getSocketFactory(conf).createSocket();
           try {
             sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
             sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);


### PR DESCRIPTION
Temporary fix for BlockReader until we implement block transfer over TLS

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-624

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
*Temporary* bug fix until we implement block transfer over TLS

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: