### PR TITLE
[HOPS-627] cleanup replicas from dead storages from the database.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/StorageMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/metadata/StorageMap.java
@@ -217,4 +217,8 @@ public class StorageMap {
   public List<Integer> getSidsForDatanodeUuid(String datanodeUuid) {
     return datanodeUuidToSids.get(datanodeUuid);
   }
+  
+  public Collection<Integer> getAllSid() {
+    return storageIdtoSId.values();
+  }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfo.java
@@ -322,6 +322,19 @@ public class BlockInfo extends Block {
     return replica;
   }
 
+  Replica removeReplica(int sid)
+      throws StorageException, TransactionContextException {
+    List<Replica> replicas = getReplicasNoCheck();
+    Replica replica = null;
+    for (Replica r : replicas) {
+      if (r.getStorageId() == sid) {
+        replica = r;
+        remove(r);
+        break;
+      }
+    }
+    return replica;
+  }
   /**
    * Returns true if this block has a replica on the given datanode.
    * @param dn

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoUnderConstruction.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockInfoUnderConstruction.java
@@ -170,8 +170,7 @@ public class BlockInfoUnderConstruction extends BlockInfo {
     // The replica list is unchanged.
     for (ReplicaUnderConstruction r : replicas) {
       if (genStamp != r.getGenerationStamp()) {
-        DatanodeDescriptor dn = datanodeMgr.getDatanodeBySid(r.getStorageId());
-        dn.removeReplica(this);
+        r.getExpectedStorageLocation(datanodeMgr).removeBlock(this);
         NameNode.blockStateChangeLog.info("BLOCK* Removing stale replica "
             + "from location: " + r.getStorageId() + " for block " + r.getBlockId());
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlocksMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlocksMap.java
@@ -183,6 +183,17 @@ class BlocksMap {
     return node.removeReplica(info);
   }
 
+  boolean removeNode(Block b, int sid)
+      throws StorageException, TransactionContextException {
+    BlockInfo info = getStoredBlock(b);
+    if (info == null) {
+      return false;
+    }
+
+    // remove block from the data-node list and the node from the block info
+    return info.removeReplica(sid)!=null;
+  }
+  
   int size() throws IOException {
     LightWeightRequestHandler getAllBlocksSizeHander =
         new LightWeightRequestHandler(HDFSOperationType.GET_ALL_BLOCKS_SIZE) {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CorruptReplicasMap.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/CorruptReplicasMap.java
@@ -191,6 +191,18 @@ public class CorruptReplicasMap {
   
   }
 
+  void forceRemoveFromCorruptReplicasMap(BlockInfo blk, int sid) throws StorageException, TransactionContextException {
+    Collection<CorruptReplica> corruptReplicas = getCorruptReplicas(blk);
+    if (corruptReplicas == null) {
+      return;
+    }
+    for (CorruptReplica c : corruptReplicas) {
+      if (c.getStorageId() == sid) {
+        removeCorruptReplicaFromDB(new CorruptReplica(c.getStorageId(), blk
+            .getBlockId(), blk.getInodeId(), c.getReason()));
+      }
+    }
+  }
 
   /**
    * Get Nodes which have corrupt replicas of Block

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -220,7 +220,7 @@ public class DatanodeManager {
     this.networktopology = NetworkTopology.getInstance(conf);
 
     this.heartbeatManager =
-        new HeartbeatManager(namesystem, blockManager, conf);
+        new HeartbeatManager(namesystem, blockManager, conf, storageMap);
 
     this.defaultXferPort = NetUtils.createSocketAddr(
         conf.get(DFSConfigKeys.DFS_DATANODE_ADDRESS_KEY,
@@ -553,6 +553,10 @@ public class DatanodeManager {
     return (node.getLastUpdate() < (Time.now() - heartbeatExpireInterval));
   }
 
+  long getHeartbeatExpireInterval(){
+    return heartbeatExpireInterval;
+  }
+  
   /**
    * Add a datanode.
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/MiniDFSCluster.java
@@ -1421,27 +1421,41 @@ public class MiniDFSCluster {
   public synchronized void restartNameNode(boolean waitActive)
       throws IOException {
     checkSingleNameNode();
-    restartNameNode(0, waitActive);
+    restartNameNode(0, waitActive, true);
   }
   
+  /**
+   * Restart the namenode. Optionally wait for the cluster to become active.
+   */
+  public synchronized void restartNameNode(boolean waitActive, boolean deleteReplicaTable)
+      throws IOException {
+    checkSingleNameNode();
+    restartNameNode(0, waitActive, false);
+  }
+    
   /**
    * Restart the namenode at a given index.
    */
   public synchronized void restartNameNode(int nnIndex) throws IOException {
-    restartNameNode(nnIndex, true);
+    restartNameNode(nnIndex, true, true);
   }
 
+  public synchronized void restartNameNode(int nnIndex, boolean waitActive)
+      throws IOException {
+    restartNameNode(nnIndex, waitActive, true);
+  }
   /**
    * Restart the namenode at a given index. Optionally wait for the cluster
    * to become active.
    */
-  public synchronized void restartNameNode(int nnIndex, boolean waitActive)
+  public synchronized void restartNameNode(int nnIndex, boolean waitActive, boolean deleteReplicaTable)
       throws IOException {
     String nnId = nameNodes[nnIndex].nnId;
     Configuration conf = nameNodes[nnIndex].conf;
     shutdownNameNode(nnIndex);
-
-    deleteReplicasTable();  // it will delete the tables if there are no active nn
+    if(deleteReplicaTable){
+      deleteReplicasTable();  // it will delete the tables if there are no active nn
+    }
 
     NameNode nn = NameNode.createNameNode(new String[]{}, conf);
     nameNodes[nnIndex] = new NameNodeInfo(nn, nnId, conf);


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-627

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
when a NN becomes a leader it checks all the storages present in the database and removes the replicas for the storages that do not match a registered data node.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: