### PR TITLE
[HOPS-629] allocated block report capacity only to alive and register…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolClientSideTranslatorPB.java
@@ -355,11 +355,12 @@ public class DatanodeProtocolClientSideTranslatorPB
   }
 
   @Override
-  public ActiveNode getNextNamenodeToSendBlockReport(long noOfBlks) throws IOException {
+  public ActiveNode getNextNamenodeToSendBlockReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException {
 
     NameNodeAddressRequestForBlockReportingProto.Builder request =
         NameNodeAddressRequestForBlockReportingProto.newBuilder();
     request.setNoOfBlks(noOfBlks);
+    request.setRegistration(PBHelper.convert(nodeReg));
     try {
       ActiveNodeProtos.ActiveNodeProto response = rpcProxy
           .getNextNamenodeToSendBlockReport(NULL_CONTROLLER, request.build());
@@ -371,11 +372,12 @@ public class DatanodeProtocolClientSideTranslatorPB
   }
 
   @Override
-  public ActiveNode getNextNamenodeToSendCacheReport(long noOfBlks) throws IOException {
+  public ActiveNode getNextNamenodeToSendCacheReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException {
 
     NameNodeAddressRequestForCacheReportingProto.Builder request =
         NameNodeAddressRequestForCacheReportingProto.newBuilder();
     request.setNoOfBlks(noOfBlks);
+    request.setRegistration(PBHelper.convert(nodeReg));
     try {
       ActiveNodeProtos.ActiveNodeProto response = rpcProxy
           .getNextNamenodeToSendCacheReport(NULL_CONTROLLER, request.build());

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/DatanodeProtocolServerSideTranslatorPB.java
@@ -300,7 +300,8 @@ public class DatanodeProtocolServerSideTranslatorPB
       NameNodeAddressRequestForBlockReportingProto request)
       throws ServiceException {
     try {
-      ActiveNode response = impl.getNextNamenodeToSendBlockReport(request.getNoOfBlks());
+      ActiveNode response = impl.getNextNamenodeToSendBlockReport(request.getNoOfBlks(), PBHelper.convert(request.
+          getRegistration()));
       ActiveNodeProtos.ActiveNodeProto responseProto =
           PBHelper.convert(response);
       return responseProto;
@@ -315,7 +316,8 @@ public class DatanodeProtocolServerSideTranslatorPB
       NameNodeAddressRequestForCacheReportingProto request)
       throws ServiceException {
     try {
-      ActiveNode response = impl.getNextNamenodeToSendCacheReport(request.getNoOfBlks());
+      ActiveNode response = impl.getNextNamenodeToSendCacheReport(request.getNoOfBlks(), PBHelper.convert(request.
+          getRegistration()));
       ActiveNodeProtos.ActiveNodeProto responseProto =
           PBHelper.convert(response);
       return responseProto;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BRTrackingService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BRTrackingService.java
@@ -25,10 +25,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hdfs.server.datanode.BRLoadBalancingException;
 
-/**
- *
- * @author salman
- */
 public class BRTrackingService {
 
   private class Work {
@@ -106,9 +102,9 @@ public class BRTrackingService {
     }
   }
 
-  private static long lastChecked = 0;
-  private static long cachedBrLbMaxBlkPerTW = -1;
-  private static long getBrLbMaxBlkPerTW(long DB_VAR_UPDATE_THRESHOLD) throws IOException {
+  private long lastChecked = 0;
+  private long cachedBrLbMaxBlkPerTW = -1;
+  private long getBrLbMaxBlkPerTW(long DB_VAR_UPDATE_THRESHOLD) throws IOException {
     if ((System.currentTimeMillis() - lastChecked) > DB_VAR_UPDATE_THRESHOLD) {
       long newValue = HdfsVariables.getBrLbMaxBlkPerTW();
       if(newValue != cachedBrLbMaxBlkPerTW){

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPOfferService.java
@@ -1350,7 +1350,7 @@ public class IncrementalBRTask implements Callable{
     BPServiceActor leaderActor = getLeaderActor();
     if (leaderActor != null) {
       try {
-        annToBR = leaderActor.nextNNForBlkReport(noOfBlks);
+        annToBR = leaderActor.nextNNForBlkReport(noOfBlks, bpRegistration);
       } catch (RemoteException e) {
         if (e.getClassName().equals(BRLoadBalancingException.class.getName())) {
           LOG.warn(e);
@@ -1371,7 +1371,7 @@ public class IncrementalBRTask implements Callable{
     BPServiceActor leaderActor = getLeaderActor();
     if (leaderActor != null) {
       try {
-        annToBR = leaderActor.nextNNForCacheReport(noOfBlks);
+        annToBR = leaderActor.nextNNForCacheReport(noOfBlks, bpRegistration);
       } catch (RemoteException e) {
         if (e.getClassName().equals(CRLoadBalancingException.class.getName())) {
           LOG.warn(e);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BPServiceActor.java
@@ -593,17 +593,17 @@ class BPServiceActor implements Runnable {
         dn.getFSDataset().getCacheUsed());
   }
   
-  public ActiveNode nextNNForBlkReport(long noOfBlks) throws IOException {
+  public ActiveNode nextNNForBlkReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException {
     if (bpNamenode != null) {
-      return bpNamenode.getNextNamenodeToSendBlockReport(noOfBlks);
+      return bpNamenode.getNextNamenodeToSendBlockReport(noOfBlks, nodeReg);
     } else {
       return null;
     }
   }
 
-  public ActiveNode nextNNForCacheReport(long noOfBlks) throws IOException {
+  public ActiveNode nextNNForCacheReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException {
     if (bpNamenode != null) {
-      return bpNamenode.getNextNamenodeToSendCacheReport(noOfBlks);
+      return bpNamenode.getNextNamenodeToSendCacheReport(noOfBlks, nodeReg);
     } else {
       return null;
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNodeRpcServer.java
@@ -1132,13 +1132,15 @@ class NameNodeRpcServer implements NamenodeProtocols {
   }
 
   @Override
-  public ActiveNode getNextNamenodeToSendBlockReport(long noOfBlks) throws IOException {
-    return nn.getNextNamenodeToSendBlockReport(noOfBlks);
+  public ActiveNode getNextNamenodeToSendBlockReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException {
+    verifyRequest(nodeReg);
+    return nn.getNextNamenodeToSendBlockReport(noOfBlks, nodeReg);
   }
   
   @Override
-  public ActiveNode getNextNamenodeToSendCacheReport(long noOfBlks) throws IOException {
-    return nn.getNextNamenodeToSendCacheReport(noOfBlks);
+  public ActiveNode getNextNamenodeToSendCacheReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException {
+    verifyRequest(nodeReg);
+    return nn.getNextNamenodeToSendCacheReport(noOfBlks, nodeReg);
   }
   
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
@@ -221,7 +221,7 @@ public interface DatanodeProtocol {
    * @return active namenode to send the next block report to
    */
   @Idempotent
-  public ActiveNode getNextNamenodeToSendBlockReport(long noOfBlks) throws IOException;
+  public ActiveNode getNextNamenodeToSendBlockReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException;
 
   /**
    * The datanode asks the leader namenode which 'namenode' to send the next
@@ -230,7 +230,7 @@ public interface DatanodeProtocol {
    * @return active namenode to send the next block report to
    */
   @Idempotent
-  public ActiveNode getNextNamenodeToSendCacheReport(long noOfBlks) throws IOException;
+  public ActiveNode getNextNamenodeToSendCacheReport(long noOfBlks, DatanodeRegistration nodeReg) throws IOException;
   
   /**
    * Read the small file data

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/proto/DatanodeProtocol.proto
@@ -382,6 +382,7 @@ message ActiveNamenodeListResponseProto {
  */
 message NameNodeAddressRequestForBlockReportingProto {
 required uint64 noOfBlks = 1;
+required DatanodeRegistrationProto registration = 2;
 }
 
 /**
@@ -389,6 +390,7 @@ required uint64 noOfBlks = 1;
 */
 message NameNodeAddressRequestForCacheReportingProto {
 required uint64 noOfBlks = 1;
+required DatanodeRegistrationProto registration = 2;
 }
 
 message GetSmallFileDataProto {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReportLoadBalancing1.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReportLoadBalancing1.java
@@ -21,54 +21,32 @@ import io.hops.leader_election.node.SortedActiveNodeListPBImpl;
 import io.hops.metadata.HdfsStorageFactory;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
+import org.apache.hadoop.hdfs.protocol.DatanodeID;
+import org.apache.hadoop.hdfs.security.token.block.ExportedBlockKeys;
 import org.apache.hadoop.hdfs.server.blockmanagement.BRTrackingService;
+import org.apache.hadoop.hdfs.server.common.StorageInfo;
 import org.apache.hadoop.hdfs.server.namenode.NameNode;
-import org.apache.hadoop.hdfs.server.protocol.DatanodeProtocol;
 import org.apache.hadoop.hdfs.server.protocol.DatanodeRegistration;
-import org.apache.hadoop.hdfs.server.protocol.StorageBlockReport;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 
 import static org.junit.Assert.*;
 
 public class TestBlockReportLoadBalancing1 {
 
   public static final Log LOG = LogFactory.getLog(TestBlockReportLoadBalancing1.class);
-  private MiniDFSCluster cluster;
-
-  @Before
-  public void startUpCluster() throws IOException {
-  }
-
-  @After
-  public void shutDownCluster() throws Exception {
-    if (cluster != null) {
-      cluster.shutdown();
-      cluster = null;
-      Thread.sleep(1000);
-    }
-  }
-
 
   @Test
   public void TestBRTrackingService_01() throws IOException, InterruptedException {
+    LOG.info("GAUTIER START");
     final int NN_COUNT = 5;
     final long DFS_BR_LB_TIME_WINDOW_SIZE = 5000;
     final long DFS_BR_LB_MAX_BLK_PER_NN_PER_TW = 100000;
@@ -121,6 +99,7 @@ public class TestBlockReportLoadBalancing1 {
 
     an = assignWork(nnList, service, 1);
     assertTrue("More work should not have been assigned", an==null);
+    LOG.info("GAUTIER STOP");
   }
 
   @Test
@@ -203,7 +182,6 @@ public class TestBlockReportLoadBalancing1 {
 
   @Test
   public void TestCommandLine() throws IOException, InterruptedException {
-    MiniDFSCluster cluster = null;
     final int NN_COUNT = 5;
     final long DFS_BR_LB_TIME_WINDOW_SIZE = 5000;
     final long DFS_BR_LB_MAX_BLK_PER_NN_PER_TW = 100000;
@@ -252,7 +230,7 @@ public class TestBlockReportLoadBalancing1 {
   }
 
   @Test
-  public void TestClusterWithOutDataNodes() throws IOException, InterruptedException {
+  public void TestClusterDataNodes() throws IOException, InterruptedException {
 
     final int NN_COUNT = 5;
     final long DFS_BR_LB_TIME_WINDOW_SIZE = 5000;
@@ -264,68 +242,118 @@ public class TestBlockReportLoadBalancing1 {
     conf.setLong(DFSConfigKeys.DFS_BR_LB_TIME_WINDOW_SIZE, DFS_BR_LB_TIME_WINDOW_SIZE);
     conf.setLong(DFSConfigKeys.DFS_BR_LB_DB_VAR_UPDATE_THRESHOLD,DFS_BR_LB_DB_VAR_UPDATE_THRESHOLD);
 
-
-
-    cluster = new MiniDFSCluster.Builder(conf)
-            .nnTopology(MiniDFSNNTopology.simpleHOPSTopology(NN_COUNT))
-            .format(true).numDataNodes(0).build();
-    cluster.waitActive();
-
-
-    ActiveNode an = null;
-    for (int i = 0; i < NN_COUNT; i++) {
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW);
-      assertTrue("Unable to assign work", an != null);
-    }
-
-
-    // more work assignment should fail
+    MiniDFSCluster cluster=null;
     try {
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW);
-      fail("More work should not have been assigned");
-    }catch(BRLoadBalancingException e){
+
+      cluster = new MiniDFSCluster.Builder(conf)
+          .nnTopology(MiniDFSNNTopology.simpleHOPSTopology(NN_COUNT))
+          .format(true).numDataNodes(1).build();
+      cluster.waitActive();
+
+      DataNode dn = cluster.getDataNodes().get(0);
+      BPOfferService bpos = dn.getAllBpOs()[0];
+
+      ActiveNode an = null;
+      for (int i = 0; i < NN_COUNT; i++) {
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW,
+            bpos.bpRegistration);
+        assertTrue("Unable to assign work", an != null);
+      }
+
+      // more work assignment should fail
+      try {
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW,
+            bpos.bpRegistration);
+        fail("More work should not have been assigned");
+      } catch (BRLoadBalancingException e) {
+      }
+
+      String[] argv = {"-setBlkRptProcessSize", NN_COUNT * DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 2 + ""};
+      try {
+        NameNode.createNameNode(argv, conf);
+      } catch (ExitUtil.ExitException e) {
+        assertEquals("setBlkRptProcessSize command should succeed", 0, e.status);
+      }
+
+      // sleep. All history will be cleared after that and more work can be  assigned
+      Thread.sleep(DFS_BR_LB_TIME_WINDOW_SIZE);
+
+      for (int i = 0; i < NN_COUNT; i++) {
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 2,
+            bpos.bpRegistration);
+        assertTrue("Unable to assign work", an != null);
+      }
+
+      // now kill some namenodes
+      cluster.shutdownNameNode(NN_COUNT - 1);
+      cluster.shutdownNameNode(NN_COUNT - 2);
+
+      // sleep. All history will be cleared after that and more work can be  assigned
+      Thread.sleep(DFS_BR_LB_TIME_WINDOW_SIZE);
+
+      for (int i = 0; i < NN_COUNT; i++) {
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport((long) (DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 0.5),
+            bpos.bpRegistration);
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport((long) (DFS_BR_LB_MAX_BLK_PER_NN_PER_TW),
+            bpos.bpRegistration);
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport((long) (DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 0.5),
+            bpos.bpRegistration);
+        assertTrue("Unable to assign work", an != null);
+      }
+
+      try {
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 2,
+            bpos.bpRegistration);
+        fail("More work should not have been assigned");
+      } catch (BRLoadBalancingException e) {
+
+      }
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
     }
-
-    String[] argv = {"-setBlkRptProcessSize", NN_COUNT * DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 2 + ""};
-    try {
-      NameNode.createNameNode(argv, conf);
-    } catch (ExitUtil.ExitException e) {
-      assertEquals("setBlkRptProcessSize command should succeed", 0, e.status);
-    }
-
-    // sleep. All history will be cleared after that and more work can be  assigned
-    Thread.sleep(DFS_BR_LB_TIME_WINDOW_SIZE);
-
-    for (int i = 0; i < NN_COUNT; i++) {
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW*2);
-      assertTrue("Unable to assign work", an != null);
-    }
-
-    // now kill some namenodes
-    cluster.shutdownNameNode(NN_COUNT-1);
-    cluster.shutdownNameNode(NN_COUNT-2);
-
-    // sleep. All history will be cleared after that and more work can be  assigned
-    Thread.sleep(DFS_BR_LB_TIME_WINDOW_SIZE);
-
-    for (int i = 0; i < NN_COUNT; i++) {
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport((long)(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW*0.5));
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport((long)(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW));
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport((long)(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW*0.5));
-      assertTrue("Unable to assign work", an != null);
-    }
-
-
-    try {
-      an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW * 2);
-      fail("More work should not have been assigned");
-    }catch(BRLoadBalancingException e){
-
-    }
-
-    cluster.shutdown();
   }
 
+//  @Test
+  public void TestUnregisteredDataNodesReport() throws IOException, InterruptedException {
+
+    final int NN_COUNT = 2;
+    final long DFS_BR_LB_TIME_WINDOW_SIZE = 5000;
+    final long DFS_BR_LB_MAX_BLK_PER_NN_PER_TW = 100000;
+    final long DFS_BR_LB_DB_VAR_UPDATE_THRESHOLD = 1000;
+
+    Configuration conf = new Configuration();
+    conf.setLong(DFSConfigKeys.DFS_BR_LB_MAX_BLK_PER_TW, NN_COUNT * DFS_BR_LB_MAX_BLK_PER_NN_PER_TW);
+    conf.setLong(DFSConfigKeys.DFS_BR_LB_TIME_WINDOW_SIZE, DFS_BR_LB_TIME_WINDOW_SIZE);
+    conf.setLong(DFSConfigKeys.DFS_BR_LB_DB_VAR_UPDATE_THRESHOLD,DFS_BR_LB_DB_VAR_UPDATE_THRESHOLD);
+
+    MiniDFSCluster cluster=null;
+    try {
+
+      cluster = new MiniDFSCluster.Builder(conf)
+          .nnTopology(MiniDFSNNTopology.simpleHOPSTopology(NN_COUNT))
+          .format(true).build();
+      cluster.waitActive();
+      
+      DatanodeRegistration dnr = new DatanodeRegistration(new DatanodeID("test:5050"), new StorageInfo(0, 0, "",
+          0, ""), ExportedBlockKeys.DUMMY_KEYS, "");
+
+      ActiveNode an = null;
+      try{
+        an = cluster.getNameNode(0).getNextNamenodeToSendBlockReport(DFS_BR_LB_MAX_BLK_PER_NN_PER_TW,
+            dnr);
+        fail("should throw a ProcessReport from dead or unregistred node exception");
+      } catch(IOException ex){
+        assertTrue("wrong error message " + ex.getMessage(), ex.getMessage().contains("ProcessReport from dead or unregistered node"));
+      }
+    } finally {
+      if (cluster != null) {
+        cluster.shutdown();
+      }
+    }
+  }
+  
   private static ActiveNode assignWork(SortedActiveNodeList nnList, BRTrackingService service, long blks){
     try
     {


### PR DESCRIPTION
…ed data nodes.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-629

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
check if a datanode is registered before to allocate it some block reporting resources.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: