### PR TITLE
[HOPS-680] Change application keystore structure and switch to Hopsworks CA V2

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2641,11 +2641,11 @@ public class YarnConfiguration extends Configuration {
   private static String HOPSWORKS_PREFIX = "hops.hopsworks";
   public static final String HOPS_HOPSWORKS_HOST_KEY = HOPSWORKS_PREFIX + ".host";
   public static final String HOPS_HOPSWORKS_LOGIN_ENDPOINT_KEY = HOPSWORKS_PREFIX + ".login.endpoint";
-  public static String DEFAULT_HOPS_HOPSWORKS_LOGIN_ENDPOINT = "hopsworks-api/api/auth/login";
+  public static String DEFAULT_HOPS_HOPSWORKS_LOGIN_ENDPOINT = "/hopsworks-api/api/auth/login";
   public static final String HOPS_HOPSWORKS_SIGN_ENDPOINT_KEY = HOPSWORKS_PREFIX + ".sign.endpoint";
-  public static String DEFAULT_HOPS_HOPSWORKS_SIGN_ENDPOINT = "hopsworks-ca/ca/agentservice/sign/app";
+  public static String DEFAULT_HOPS_HOPSWORKS_SIGN_ENDPOINT = "/hopsworks-ca/v2/certificate/app";
   public static final String HOPS_HOPSWORKS_REVOKE_ENDPOINT_KEY = HOPSWORKS_PREFIX + ".revoke.endpoint";
-  public static String DEFAULT_HOPS_HOPSWORKS_REVOKE_ENDPOINT = "hopsworks-ca/ca/agentservice/revoke";
+  public static String DEFAULT_HOPS_HOPSWORKS_REVOKE_ENDPOINT = "/hopsworks-ca/v2/certificate/app?";
   public static final String RM_APP_CERTIFICATE_EXPIRATION_SAFETY_PERIOD =
       RM_PREFIX + "certificate.expiration-safety-period";
   public static String DEFAULT_RM_APP_CERTIFICATE_RENEWER_DELAY = "2d";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2870,13 +2870,13 @@
   <property>
     <description>Hopworks REST endpoint for agent to send application CSR</description>
     <name>hops.hopsworks.sign.endpoint</name>
-    <value>hopsworks-ca/ca/agentservice/sign/app</value>
+    <value>hopsworks-ca/v2/certificate/app</value>
   </property>
 
   <property>
     <description>Hopsworks REST endpoint for agent to send certificate revocation request</description>
     <name>hops.hopsworks.revoke.endpoint</name>
-    <value>hopsworks-ca/ca/agentservice/revoke</value>
+    <value>hopsworks-ca/v2/certificate/app?</value>
   </property>
 
   <property>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/RMAppCertificateActions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/RMAppCertificateActions.java
@@ -27,6 +27,6 @@ import java.security.cert.X509Certificate;
 
 public interface RMAppCertificateActions {
   void init() throws MalformedURLException, GeneralSecurityException;
-  X509Certificate sign(PKCS10CertificationRequest csr) throws URISyntaxException, IOException, GeneralSecurityException;
+  RMAppCertificateManager.CertificateBundle sign(PKCS10CertificationRequest csr) throws URISyntaxException, IOException, GeneralSecurityException;
   int revoke(String certificateIdentifier) throws URISyntaxException, IOException, GeneralSecurityException;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestingRMAppCertificateActions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestingRMAppCertificateActions.java
@@ -105,7 +105,8 @@ public class TestingRMAppCertificateActions implements RMAppCertificateActions, 
   }
   
   @Override
-  public X509Certificate sign(PKCS10CertificationRequest csr) throws URISyntaxException, IOException, GeneralSecurityException {
+  public RMAppCertificateManager.CertificateBundle sign(PKCS10CertificationRequest csr)
+      throws URISyntaxException, IOException, GeneralSecurityException {
     JcaPKCS10CertificationRequest jcaRequest = new JcaPKCS10CertificationRequest(csr);
     X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(caCert,
         BigInteger.valueOf(System.currentTimeMillis()),
@@ -120,9 +121,9 @@ public class TestingRMAppCertificateActions implements RMAppCertificateActions, 
             .createSubjectKeyIdentifier(jcaRequest.getPublicKey()))
         .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
         .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
-    
-    return new JcaX509CertificateConverter().setProvider("BC")
+    X509Certificate certificate = new JcaX509CertificateConverter().setProvider("BC")
         .getCertificate(certBuilder.build(sigGen));
+    return new RMAppCertificateManager.CertificateBundle(certificate, caCert);
   }
   
   @Override


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-680

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
Application keystore will contain its certificate/private key and the intermediate CA certificate as a bundle. Keystore will contain Hops Root CA certificate.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Also, https://logicalclocks.atlassian.net/browse/HOPSWORKS-697