### PR TITLE
[HOPS-807] SetOwner should update the usersgroups cache on all namenodes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -2212,6 +2212,7 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
     checkOpen();
     try {
       namenode.setOwner(src, username, groupname);
+      updateUserGroupCacheOnOtherNamenode(username, groupname);
     } catch(RemoteException re) {
       throw re.unwrapRemoteException(AccessControlException.class,
                                      FileNotFoundException.class,
@@ -2991,6 +2992,11 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
       throw re.unwrapRemoteException();
     }
     
+    updateUserGroupCacheOnOtherNamenode(userName, groupName);
+  }
+  
+  private void updateUserGroupCacheOnOtherNamenode(final String userName, final String groupName)
+      throws IOException {
     if(userName != null && groupName != null){
       for(ClientProtocol nn : allNNs) {
         try{


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-807

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: