### PR TITLE
[HOPS-813] DFSClient.close should close connection to all namenodes

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -864,10 +864,14 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
   }
 
   /**
-   * Close connections the Namenode.
+   * Close connections the Namenodes.
    */
-  void closeConnectionToNamenode() {
+  void closeConnectionToNamenodes() {
     RPC.stopProxy(namenode);
+    RPC.stopProxy(leaderNN);
+    for(ClientProtocol nn : allNNs){
+      RPC.stopProxy(nn);
+    }
   }
 
   /** Abort and release resources held.  Ignore all errors. */
@@ -881,7 +885,7 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
     } catch (IOException ioe) {
        LOG.info("Exception occurred while aborting the client " + ioe);
     }
-    closeConnectionToNamenode();
+    closeConnectionToNamenodes();
   }
 
   /** Close/abort all files being written. */
@@ -921,8 +925,8 @@ public class DFSClient implements java.io.Closeable, RemotePeerFactory {
       closeAllFilesBeingWritten(false);
       clientRunning = false;
       getLeaseRenewer().closeClient(this);
-      // close connections to the namenode
-      closeConnectionToNamenode();
+      // close connections to the namenodes
+      closeConnectionToNamenodes();
     }
   }
 


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-813

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: