### PR TITLE
[HOPS-1048] Truncate retry cache table on cluster restart

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/handler/HDFSOperationType.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/handler/HDFSOperationType.java
@@ -352,6 +352,7 @@ public enum HDFSOperationType implements OperationType {
   //retry cache
   RETRY_CACHE,
   CLEAN_RETRY_CACHE,
+  CLEAR_RETRY_CACHE,
 
   //Metadata GC
   MDCLEANER,


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1048

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Depends on hopshadoop/hops-metadata-dal#149 and hopshadoop/hops-metadata-dal-impl-ndb#181