### PR TITLE
[HOPS-6] Availability Zone Awareness support for HopsFS

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/leader_election/node/ActiveNode.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/leader_election/node/ActiveNode.java
@@ -36,5 +36,7 @@ public interface ActiveNode extends Comparable<ActiveNode> {
   public InetSocketAddress getRpcServerAddressForDatanodes();
 
   public String getHttpAddress();
+  
+  public int getLocationDomainId();
 
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/leader_election/node/ActiveNodePBImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/leader_election/node/ActiveNodePBImpl.java
@@ -17,6 +17,7 @@ package io.hops.leader_election.node;
 
 import io.hops.leader_election.proto.ActiveNodeProtos.ActiveNodeProto;
 import io.hops.leader_election.proto.ActiveNodeProtos.ActiveNodeProtoOrBuilder;
+import io.hops.metadata.election.entity.LeDescriptor;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -41,11 +42,19 @@ public class ActiveNodePBImpl implements ActiveNode {
             proto.getRpcPort(),
             proto.getHttpAddress(),
             proto.getServiceIpAddress(),
-            proto.getServicePort());
+            proto.getServicePort(),
+            proto.getLocationDomainId());
   }
-
+  
   public ActiveNodePBImpl(long id, String hostname, String ipAddress, int port,
       String httpAddress, String serviceRpcIp, int serviceRpcPort) {
+    this(id, hostname, ipAddress, port, httpAddress, serviceRpcIp,
+        serviceRpcPort, LeDescriptor.DEFAULT_LOCATION_DOMAIN_ID);
+  }
+  
+  public ActiveNodePBImpl(long id, String hostname, String ipAddress, int port,
+      String httpAddress, String serviceRpcIp, int serviceRpcPort,
+      int locationDomainId) {
     maybeInitBuilder();
     builder.setId(id);
     builder.setRpcHostname(hostname);
@@ -54,6 +63,7 @@ public class ActiveNodePBImpl implements ActiveNode {
     builder.setHttpAddress(httpAddress);
     builder.setServiceIpAddress(serviceRpcIp);
     builder.setServicePort(serviceRpcPort);
+    builder.setLocationDomainId(locationDomainId);
   }
 
   public ActiveNodeProto getProto() {
@@ -127,7 +137,13 @@ public class ActiveNodePBImpl implements ActiveNode {
     ActiveNodeProtoOrBuilder p = viaProto ? proto : builder;
     return p.getHttpAddress();
   }
-
+  
+  @Override
+  public int getLocationDomainId() {
+    ActiveNodeProtoOrBuilder p = viaProto ? proto : builder;
+    return p.getLocationDomainId();
+  }
+  
   public void setHttpAddress(String httpAddress) {
     maybeInitBuilder();
     builder.setHttpAddress(httpAddress);

--- a/hadoop-common-project/hadoop-common/src/main/proto/ActiveNode.proto
+++ b/hadoop-common-project/hadoop-common/src/main/proto/ActiveNode.proto
@@ -36,7 +36,8 @@ message ActiveNodeProto {
   optional string serviceIpAddress = 5;
   optional int32 servicePort = 6;
   optional string httpAddress = 7;
-  extensions 8 to 8;
+  optional int32 locationDomainId = 8;
+  extensions 9 to 9;
 }
 
 message SortedActiveNodeListProto{

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1072,4 +1072,8 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String NNTOP_WINDOWS_MINUTES_KEY =
       "dfs.namenode.top.windows.minutes";
   public static final String[] NNTOP_WINDOWS_MINUTES_DEFAULT = {"1","5","25"};
+  
+  public static final String DFS_LOCATION_DOMAIN_ID = "dfs.locationDomainId";
+  public static final byte DFS_LOCATION_DOMAIN_ID_DEFAULT = 0;
+  
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolServerSideTranslatorPB.java
@@ -1193,6 +1193,7 @@ public class ClientNamenodeProtocolServerSideTranslatorPB
     anp.setHttpAddress(p.getHttpAddress());
     anp.setServiceIpAddress(p.getServiceRpcIpAddress());
     anp.setServicePort(p.getServiceRpcPort());
+    anp.setLocationDomainId(p.getLocationDomainId());
     return anp.build();
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/ClientNamenodeProtocolTranslatorPB.java
@@ -1103,7 +1103,8 @@ public class ClientNamenodeProtocolTranslatorPB
   private ActiveNode convertProtoANToAN(ActiveNodeProtos.ActiveNodeProto p) {
     ActiveNode an =
         new ActiveNodePBImpl(p.getId(), p.getRpcHostname(), p.getRpcIpAddress(),
-            p.getRpcPort(), p.getHttpAddress(),p.getServiceIpAddress(), p.getServicePort());
+            p.getRpcPort(), p.getHttpAddress(),p.getServiceIpAddress(),
+            p.getServicePort(), p.getLocationDomainId());
     return an;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelper.java
@@ -2035,7 +2035,8 @@ public class PBHelper {
   public static ActiveNode convert(ActiveNodeProto p) {
     ActiveNode an =
         new ActiveNodePBImpl(p.getId(), p.getRpcHostname(), p.getRpcIpAddress(),
-            p.getRpcPort(), p.getHttpAddress(), p.getServiceIpAddress(), p.getServicePort());
+            p.getRpcPort(), p.getHttpAddress(), p.getServiceIpAddress(),
+            p.getServicePort(), p.getLocationDomainId());
     return an;
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1369,7 +1369,8 @@ public class NameNode implements NameNodeStatusMXBean {
     leaderElection =
         new LeaderElection(new HdfsLeDescriptorFactory(), leadercheckInterval,
             missedHeartBeatThreshold, leIncrement, httpAddress,
-            rpcAddresses);
+            rpcAddresses, (byte) conf.getInt(DFSConfigKeys.DFS_LOCATION_DOMAIN_ID,
+            DFSConfigKeys.DFS_LOCATION_DOMAIN_ID_DEFAULT));
     leaderElection.start();
 
     try {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/FailoverProxyHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/FailoverProxyHelper.java
@@ -38,9 +38,11 @@ public class FailoverProxyHelper {
   protected static class AddressRpcProxyPair<T> {
     public InetSocketAddress address;
     public T namenode;
-
-    public AddressRpcProxyPair(InetSocketAddress address) {
+    public int index;
+    
+    public AddressRpcProxyPair(InetSocketAddress address, int index) {
       this.address = address;
+      this.index = index;
     }
 
     @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1910,4 +1910,18 @@
   </description>
 </property>
 
+  <property>
+    <name>dfs.locationDomainId</name>
+    <value>0</value>
+    <description> Assign a namenode to a specific availability
+      domain (availability zone). The client uses this information to
+      preferably choose a namenode from its availability domain (have the same
+      locationDomainId), otherwise it will pick up a random namenode. The
+      locationDomainIds has to be the same as the ones set in the NDB
+      datanodes to enforce communications between namenodes and NDB datanodes
+      in the same availability domain. This feature is disabled by default by
+      setting its value to 0.
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto/yarn_GroupMembership_service.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/proto/yarn_GroupMembership_service.proto
@@ -26,7 +26,7 @@ package hops.yarnGroupMembership;
 import "ActiveNode.proto";
 
 extend hadoop.common.ActiveNodeProto {
-  optional int64 load = 8;
+  optional int64 load = 9;
 }
 
 service GroupMembershipService {

--- a/hops-leader-election/src/main/java/io/hops/leaderElection/HdfsLeDescriptorFactory.java
+++ b/hops-leader-election/src/main/java/io/hops/leaderElection/HdfsLeDescriptorFactory.java
@@ -37,15 +37,15 @@ public class HdfsLeDescriptorFactory extends LeDescriptorFactory {
 
   @Override
   public LeDescriptor getNewDescriptor(long id, long counter, String hostName,
-      String httpAddress) {
+      String httpAddress, byte locationDomainId) {
     return new LeDescriptor.HdfsLeDescriptor(id, counter, hostName,
-        httpAddress);
+        httpAddress, locationDomainId);
   }
 
   @Override
   public LeDescriptor cloneDescriptor(LeDescriptor desc) {
     return new LeDescriptor.HdfsLeDescriptor(desc.getId(), desc.getCounter(),
-        desc.getRpcAddresses(), desc.getHttpAddress());
+        desc.getRpcAddresses(), desc.getHttpAddress(), desc.getLocationDomainId());
   }
 
   @Override

--- a/hops-leader-election/src/main/java/io/hops/leaderElection/LEContext.java
+++ b/hops-leader-election/src/main/java/io/hops/leaderElection/LEContext.java
@@ -39,7 +39,8 @@ public class LEContext {
   protected long time_period_increment;
   protected boolean nextTimeTakeStrongerLocks;
   protected List<LeDescriptor> removedNodes; //nodes removed during this round
-
+  protected byte locationDomainId;
+  
   private LEContext() {
   }
 
@@ -55,7 +56,8 @@ public class LEContext {
     http_address = context.http_address;
     time_period_increment = context.time_period_increment;
     nextTimeTakeStrongerLocks = context.nextTimeTakeStrongerLocks;
-
+    locationDomainId = context.locationDomainId;
+    
     //clone history
     history = new ArrayList<HashMap<Long, LeDescriptor>>();
     if (!context.history.isEmpty()) {

--- a/hops-leader-election/src/main/java/io/hops/leaderElection/LETransaction.java
+++ b/hops-leader-election/src/main/java/io/hops/leaderElection/LETransaction.java
@@ -176,7 +176,7 @@ public class LETransaction {
         context.id = getNewNamenondeID();
         LeDescriptor newDescriptor = leFactory
             .getNewDescriptor(context.id, 0/*counter*/, context.rpc_addresses,
-                context.http_address);
+                context.http_address, context.locationDomainId);
         EntityManager.add(newDescriptor);
         if (oldId != LeaderElection.LEADER_INITIALIZATION_ID) {
           LOG.warn( "LE Status: id " + context.id + " I was kicked out. Old Id was " + oldId);
@@ -355,7 +355,7 @@ public class LETransaction {
       String httpAddress = l.getHttpAddress();
       ActiveNode ann =
           new ActiveNodePBImpl(l.getId(), l.getRpcAddresses(), hostName[0], port[0],
-              httpAddress, hostName[1], port[1]);
+              httpAddress, hostName[1], port[1], l.getLocationDomainId());
       activeNameNodeList.add(ann);
     }
 

--- a/hops-leader-election/src/main/java/io/hops/leaderElection/LeaderElection.java
+++ b/hops-leader-election/src/main/java/io/hops/leaderElection/LeaderElection.java
@@ -49,10 +49,20 @@ public class LeaderElection extends Thread {
   private boolean relinquishCurrentId = false;
   private final LeDescriptorFactory leFactory;
   private List<FailedNodeLeDescriptor> deadNodes;
-
+  
   public LeaderElection(final LeDescriptorFactory leFactory,
       final long time_period, final int max_missed_hb_threshold,
-      final long time_period_increment, String http_address, String rpc_addresses)
+      final long time_period_increment, String http_address,
+      String rpc_addresses) throws IOException{
+    this(leFactory, time_period, max_missed_hb_threshold,
+        time_period_increment, http_address, rpc_addresses,
+        LeDescriptor.DEFAULT_LOCATION_DOMAIN_ID);
+  }
+  
+  public LeaderElection(final LeDescriptorFactory leFactory,
+      final long time_period, final int max_missed_hb_threshold,
+      final long time_period_increment, String http_address,
+      String rpc_addresses, byte locationDomainId)
       throws IOException {
     context = LEContext.initialContext();
     context.init_phase = true;
@@ -61,6 +71,7 @@ public class LeaderElection extends Thread {
     context.rpc_addresses = rpc_addresses;
     context.http_address = http_address;
     context.time_period_increment = time_period_increment;
+    context.locationDomainId = locationDomainId;
     this.leFactory = leFactory;
     this.deadNodes = new ArrayList<FailedNodeLeDescriptor>();
     initialize();

--- a/hops-leader-election/src/main/java/io/hops/leaderElection/YarnLeDescriptorFactory.java
+++ b/hops-leader-election/src/main/java/io/hops/leaderElection/YarnLeDescriptorFactory.java
@@ -37,14 +37,14 @@ public class YarnLeDescriptorFactory extends LeDescriptorFactory {
   
   @Override
   public LeDescriptor getNewDescriptor(long id, long counter, String hostName,
-      String httpAddress) {
-    return new YarnLeDescriptor(id, counter, hostName, httpAddress);
+      String httpAddress, byte locationDomainId) {
+    return new YarnLeDescriptor(id, counter, hostName, httpAddress, locationDomainId);
   }
 
   @Override
   public LeDescriptor cloneDescriptor(LeDescriptor desc) {
     return new YarnLeDescriptor(desc.getId(), desc.getCounter(),
-        desc.getRpcAddresses(), desc.getHttpAddress());
+        desc.getRpcAddresses(), desc.getHttpAddress(), desc.getLocationDomainId());
   }
 
   @Override


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-6

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the new behavior (if this is a feature change)?**
Admins can assign a namenode to a specific availability zone using a new configuration parameter in hdfs-site. Users can also assign their clients to a specific availability zone to enforce using a namenode from the same availability zone.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
https://github.com/hopshadoop/hops-metadata-dal/pull/150
https://github.com/hopshadoop/hops-metadata-dal-impl-ndb/pull/182