### PR TITLE
[HOPS-1101] secondary NN initilaize repl queues even out of safe mode

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -869,8 +869,8 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       prog.setTotal(Phase.SAFEMODE, STEP_AWAITING_REPORTED_BLOCKS,
           getCompleteBlocksTotal());
       setBlockTotal();
+      shouldPopulateReplicationQueue = true;
     }
-    shouldPopulateReplicationQueue = true;
     blockManager.activate(conf);
     if (dir.isQuotaEnabled()) {
       quotaUpdateManager.activate();
@@ -907,13 +907,13 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
     try {
       blockManager.getDatanodeManager().markAllDatanodesStale();
 
-      if (isLeader()) {
-        // the node is starting and directly leader, this means that no NN was alive before
-        // Only need to re-process the queue, If not in SafeMode.
-        if (!isInSafeMode()) {
-          LOG.info("Reprocessing replication and invalidation queues");
-          initializeReplQueues();
-        } else {
+      // Only need to re-process the queue, If not in SafeMode.
+      if (!isInSafeMode()) {
+        LOG.info("Reprocessing replication and invalidation queues");
+        initializeReplQueues();
+      } else {
+        if (isLeader()) {
+          // the node is starting and directly leader, this means that no NN was alive before
           HdfsVariables.resetMisReplicatedIndex();
         }
       }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1101

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: