### PR TITLE
[HOPS-1133] NormalUserCertLocServiceHopsSSLCheck should not throw an …

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/NormalUserCertLocServiceHopsSSLCheck.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/NormalUserCertLocServiceHopsSSLCheck.java
@@ -45,11 +45,8 @@ public class NormalUserCertLocServiceHopsSSLCheck extends AbstractHopsSSLCheck {
   
       if (certificateLocalization != null) {
         try {
-          String appId = ugi.getApplicationId();
-          if (appId == null) {
-            throw new IOException("UserGroupInformation does NOT contain the Application ID");
-          }
-          X509SecurityMaterial material = certificateLocalization.getX509MaterialLocation(username, appId);
+          X509SecurityMaterial material =
+              certificateLocalization.getX509MaterialLocation(username, ugi.getApplicationId());
           
           return new HopsSSLCryptoMaterial(
               material.getKeyStoreLocation().toString(),


### PR DESCRIPTION
…exception if AppId is null

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-1133


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: