### PR TITLE
[HOPS-1149]  Take exclusive fd lock and remove I/O operations from NM's heartbeat loop

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CertificateLocalization.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/CertificateLocalization.java
@@ -53,9 +53,9 @@ public interface CertificateLocalization {
       throws FileNotFoundException, InterruptedException;
   
   void updateX509(String username, String applicationId, ByteBuffer keyStore, String keyStorePassword,
-      ByteBuffer trustStore, String trustStorePassword) throws IOException, InterruptedException;
+      ByteBuffer trustStore, String trustStorePassword) throws InterruptedException;
   
-  void updateJWT(String username, String applicationId, String jwt) throws IOException, InterruptedException;
+  void updateJWT(String username, String applicationId, String jwt) throws InterruptedException;
   
   String getSuperKeystoreLocation();
   


### PR DESCRIPTION
[HOPS-1149]  Take exclusive file descriptor lock when updating crypto material for container
[HOPS-1149]  Remove IO operations from NM heartbeat loop

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1149

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
When NM receives an updated security material (X.509 or JWT), it acquires an exclusive lock on the file descriptor so another process (if it's a good citizen) would be blocked. Also, remove I/O operations for updating local files from NodeManager's heartbeat loop.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

* **Other information**: