### PR TITLE
[HOPS-1311]  Adapt service JWT renewer to new protocol

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2691,11 +2691,17 @@ public class YarnConfiguration extends Configuration {
   public static final String RM_JWT_RENEW_PATH = RM_PREFIX + JWT_PREFIX
       + "renew-path";
   
-  public static String DEFAULT_RM_JWT_ALIVE_PATH = "/hopsworks-ca/v2/token";
-  public static final String RM_JWT_ALIVE_PATH = RM_PREFIX + JWT_PREFIX + "alive-path";
+  public static String DEFAULT_RM_JWT_SERVICE_RENEW_PATH = "/hopsworks-api/api/jwt/renew/service";
+  public static final String RM_JWT_SERVICE_RENEW_PATH = RM_PREFIX + JWT_PREFIX
+      + "service-renew-path";
   
-  public static final String RM_JWT_TOKEN = RM_PREFIX + JWT_PREFIX + "token";
+  public static String DEFAULT_RM_JWT_SERVICE_INVALIDATE_PATH = "/hopsworks-api/api/jwt/invalidate/service/";
+  public static final String RM_JWT_SERVICE_INVALIDATE_PATH = RM_PREFIX + JWT_PREFIX
+      + "service-invalidate-path";
   
+  public static final String RM_JWT_MASTER_TOKEN = RM_PREFIX + JWT_PREFIX + "master-token";
+  
+  public static final String RM_JWT_RENEW_TOKEN_PATTERN = RM_PREFIX + JWT_PREFIX + "renew-token-%d";
   public static long DEFAULT_RM_JWT_ALIVE_INTERVAL = 1800;
   public static final String RM_JWT_ALIVE_INTERVAL = RM_PREFIX + JWT_PREFIX + "alive-interval";
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -2702,6 +2702,8 @@ public class YarnConfiguration extends Configuration {
   public static final String RM_JWT_MASTER_TOKEN = RM_PREFIX + JWT_PREFIX + "master-token";
   
   public static final String RM_JWT_RENEW_TOKEN_PATTERN = RM_PREFIX + JWT_PREFIX + "renew-token-%d";
-  public static long DEFAULT_RM_JWT_ALIVE_INTERVAL = 1800;
-  public static final String RM_JWT_ALIVE_INTERVAL = RM_PREFIX + JWT_PREFIX + "alive-interval";
+  
+  // 5 days
+  public static long DEFAULT_RM_JWT_MASTER_VALIDITY_PERIOD = 432000;
+  public static final String RM_JWT_MASTER_VALIDITY_PERIOD = RM_PREFIX + JWT_PREFIX + "master-token-validity";
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/test/java/org/apache/hadoop/yarn/conf/TestYarnConfigurationFields.java
@@ -146,5 +146,8 @@ public class TestYarnConfigurationFields extends TestConfigurationFieldsBase {
 
     // Currently defined in RegistryConstants/core-site.xml
     xmlPrefixToSkipCompare.add("hadoop.registry");
+    
+    // Used as template for variable number of master JWT renew tokens. %d is a sequence number
+    xmlPropsToSkipCompare.add("yarn.resourcemanager.rmappsecurity.jwt.renew-token-%d");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/resources/yarn-default.xml
@@ -2929,20 +2929,35 @@
   </property>
 
   <property>
-    <description>Hopsworks REST endpoint to ping for automatic JWT renewal</description>
-    <name>yarn.resourcemanager.rmappsecurity.jwt.alive-path</name>
-    <value>/hopsworks-ca/v2/token</value>
+    <description>Hopsworks REST endpoint to send service JWT renew requests</description>
+    <name>yarn.resourcemanager.rmappsecurity.jwt.service-renew-path</name>
+    <value>/hopsworks-api/api/jwt/renew/service</value>
   </property>
 
   <property>
-    <description>Interval to ping Hopsworks to renew JWT</description>
-    <name>yarn.resourcemanager.rmappsecurity.jwt.alive-interval</name>
-    <value>30m</value>
+    <description>Hopsworks REST endpoint to send service JWT invalidate requests</description>
+    <name>yarn.resourcemanager.rmappsecurity.jwt.service-invalidate-path</name>
+    <value>/hopsworks-api/api/jwt/invalidate/service/</value>
   </property>
 
   <property>
-    <description>Valid JWT used by RMAppSecurityManager</description>
-    <name>yarn.resourcemanager.rmappsecurity.jwt.token</name>
-    <value>Encoded token</value>
+    <description>Validity period of master JWT. If suffix is omitted, defaults to seconds
+      Available suffices are (s)econds, (m)inutes, (h)ours and (d)ays</description>
+    <name>yarn.resourcemanager.rmappsecurity.jwt.master-token-validity</name>
+    <value>432000</value>
   </property>
+
+  <property>
+    <description>Master service JWT to communicate with Hopsworks.
+      It should be located in ssl-server.xml</description>
+    <name>yarn.resourcemanager.rmappsecurity.jwt.master-token</name>
+  </property>
+
+  <property>
+    <description>Variable number of one-time JWTs used to renew the master
+      token with Hopsworks. %d is a placeholder for sequence numbers starting from 0.
+      They should be located in ssl-server.xml</description>
+    <name>yarn.resourcemanager.rmappsecurity.jwt.renew-token-%d</name>
+  </property>
+
 </configuration>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/MockJWTIssuer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/MockJWTIssuer.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server.resourcemanager.security;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.text.ParseException;
+
+public class MockJWTIssuer {
+  
+  private final byte[] sharedSecret;
+  private final JWSSigner signer;
+  private final JWSVerifier verifier;
+  
+  public MockJWTIssuer(byte[] sharedSecret) {
+    this.sharedSecret = sharedSecret;
+    signer = new MACSigner(sharedSecret);
+    verifier = new MACVerifier(sharedSecret);
+  }
+  
+  public String generate(JWTClaimsSet claims) throws JOSEException {
+    claims.setIssuer("MockJWTIssuer");
+    SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+    signedJWT.sign(signer);
+    
+    return signedJWT.serialize();
+  }
+  
+  public boolean verify(String token) throws ParseException, JOSEException {
+    SignedJWT jwt = SignedJWT.parse(token);
+    return jwt.verify(verifier);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestX509SecurityHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestX509SecurityHandler.java
@@ -120,7 +120,6 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
   @Before
   public void beforeTest() throws Exception {
     conf = new Configuration();
-    conf.set(YarnConfiguration.HOPS_HOPSWORKS_HOST_KEY, "https://bbc3.sics.se:33478");
     conf.set(YarnConfiguration.RM_APP_CERTIFICATE_EXPIRATION_SAFETY_PERIOD, "5s");
     RMAppSecurityActionsFactory.getInstance().clear();
     RMStorageFactory.setConfiguration(conf);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MockHopsworksRMAppSecurityActions.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/MockHopsworksRMAppSecurityActions.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.yarn.server;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.apache.hadoop.yarn.server.resourcemanager.security.HopsworksRMAppSecurityActions;
+import org.apache.hadoop.yarn.server.resourcemanager.security.MockJWTIssuer;
+
+import java.net.MalformedURLException;
+import java.security.GeneralSecurityException;
+import java.sql.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Random;
+
+public class MockHopsworksRMAppSecurityActions extends HopsworksRMAppSecurityActions {
+  private final byte[] secret;
+  private final MockJWTIssuer jwtIssuer;
+  
+  public MockHopsworksRMAppSecurityActions() throws MalformedURLException, GeneralSecurityException {
+    super();
+    Random rand = new Random();
+    secret = new byte[32];
+    rand.nextBytes(secret);
+    jwtIssuer = new MockJWTIssuer(secret);
+  }
+  
+  @Override
+  protected void loadMasterJWT() throws GeneralSecurityException {
+    LocalDateTime masterExpiration = LocalDateTime.now().plus(10L, ChronoUnit.MINUTES);
+    JWTClaimsSet claims = new JWTClaimsSet();
+    claims.setExpirationTime(Date.from(masterExpiration.atZone(ZoneId.systemDefault()).toInstant()));
+    try {
+      String masterToken = jwtIssuer.generate(claims);
+      setMasterToken(masterToken);
+      setMasterTokenExpiration(masterExpiration);
+    } catch (JOSEException ex) {
+      throw new GeneralSecurityException(ex.getMessage(), ex);
+    }
+  }
+  
+  @Override
+  protected void loadRenewalJWTs() throws GeneralSecurityException {
+    setRenewalTokens(new String[0]);
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnStartupWithCRL.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnStartupWithCRL.java
@@ -76,6 +76,10 @@ public class TestYarnStartupWithCRL {
     conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.YARN_MINICLUSTER_FIXED_PORTS, true);
     conf.setBoolean(YarnConfiguration.YARN_MINICLUSTER_USE_RPC, true);
+    
+    conf.set(YarnConfiguration.HOPS_RM_SECURITY_ACTOR_KEY,
+        MockHopsworksRMAppSecurityActions.class.getName());
+    
     CRLValidatorFactory.getInstance().clearCache();
     CRLFetcherFactory.getInstance().clearFetcherCache();
   }


### PR DESCRIPTION
[HOPS-1311]  Make paths configurable

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [ ] HOPS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit
- [ ] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1311

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
Keep compliant with Hopsworks protocol for updating service JWTs

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
When Hops TLS is enabled or when Yarn is configured to manage applications' JWT, Hops won't be compatible with older versions of Hopsworks

* **Other information**: