### PR TITLE
[HOPS-1348] alter xattr table - decrease size of xattr value

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2009,7 +2009,7 @@
     <value>13755</value>
     <description>
       The maximum combined size of the name and value of an extended
-      attribute in bytes. The maximum allowed size is 13255 where the name
+      attribute in bytes. The maximum allowed size is 13755 where the name
       can take up to 255 bytes, and the value size can take up to 13500
       bytes. If set to 0 the maximum allowed size 13755 is used.
     </description>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2006,12 +2006,12 @@
 
   <property>
     <name>dfs.namenode.fs-limits.max-xattr-size</name>
-    <value>13985</value>
+    <value>13755</value>
     <description>
       The maximum combined size of the name and value of an extended
-      attribute in bytes. The maximum allowed size is 13985, where the name
-      can take up to 255 bytes, and the value size can take up to 13730
-      bytes. If set to 0 the maximum allowed size (13985) is used.
+      attribute in bytes. The maximum allowed size is 13255 where the name
+      can take up to 255 bytes, and the value size can take up to 13500
+      bytes. If set to 0 the maximum allowed size 13755 is used.
     </description>
   </property>
 


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit
- [ ] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-1348

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature change

* **What is the new behavior (if this is a feature change)?**
feature change - XAttr

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It changes the db. If anyone used XAttr and added values of max size - this would be a big breaking change.

* **Other information**:
https://github.com/hopshadoop/hops-metadata-dal/pull/165
https://github.com/hopshadoop/hops-metadata-dal-impl-ndb/pull/206


