### PR TITLE
[HOPS-1365] fix getBlocks to be faster and not kill the DB

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -68,7 +68,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_NAMENODE_IDSMONITOR_CHECK_INTERVAL_IN_MS = "dfs.namenode.id.updateThreshold";
   public static final int DFS_NAMENODE_IDSMONITOR_CHECK_INTERVAL_IN_MS_DEFAULT = 1000;
   public static final String DFS_NAMENODE_PROCESS_REPORT_BATCH_SIZE = "dfs.namenode.processReport.batchsize";
-  public static final int DFS_NAMENODE_PROCESS_REPORT_BATCH_SIZE_DEFAULT = 10;
+  public static final int DFS_NAMENODE_PROCESS_REPORT_BATCH_SIZE_DEFAULT = 500;
   public static final String DFS_NAMENODE_PROCESS_MISREPLICATED_BATCH_SIZE = "dfs.namenode.misreplicated.batchsize";
   public static final int DFS_NAMENODE_PROCESS_MISREPLICATED_BATCH_SIZE_DEFAULT = 500;
   public static final String DFS_NAMENODE_PROCESS_MISREPLICATED_NO_OF_BATCHS = "dfs.namenode.misreplicated.noofbatches";
@@ -161,7 +161,7 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final int DEFAULT_DELETION_LIMIT = 100;
 
   public static final String DFS_BR_LB_MAX_CONCURRENT_BR_PER_NN = "dfs.block.report.load.balancer.max.concurrent.block.reports.per.nn";
-  public static final long DFS_BR_LB_MAX_CONCURRENT_BR_PER_NN_DEFAULT = 5;
+  public static final long DFS_BR_LB_MAX_CONCURRENT_BR_PER_NN_DEFAULT = 1;
 
   //read the new value from the data base after every minute
   public static final String DFS_BR_LB_DB_VAR_UPDATE_THRESHOLD = "dfs.block.report.load.balancing.db.var.update.threashold";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -709,6 +709,7 @@ public class FSNamesystem implements Namesystem, FSNamesystemMBean,
       
       this.maxDBTries = conf.getInt(DFSConfigKeys.DFS_NAMENODE_DB_CHECK_MAX_TRIES,
           DFSConfigKeys.DFS_NAMENODE_DB_CHECK_MAX_TRIES_DEFAULT);
+      DatanodeStorageInfo.BLOCKITERATOR_BATCH_SIZE = slicerBatchSize;
     } catch (IOException | RuntimeException e) {
       LOG.error(getClass().getSimpleName() + " initialization failed.", e);
       close();


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1365

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
depends on hopshadoop/hops-metadata-dal#168 and hopshadoop/hops-metadata-dal-impl-ndb#209