### PR TITLE
[HOPS-1525] Use configurable Socket Factory when connecting to DN's Xceiver instead of the DefaultSocketFactory

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -621,6 +621,11 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final String DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_KEY = "dfs.datanode.xceiver.stop.timeout.millis";
   public static final long   DFS_DATANODE_XCEIVER_STOP_TIMEOUT_MILLIS_DEFAULT = 60000;
   
+  // Socket factory for the DFSClient to use when connecting to DataXceiver
+  // See HOPS-1525
+  public static final String DFS_CLIENT_XCEIVER_SOCKET_FACTORY_CLASS_KEY = "dfs.client.xceiver.socket.factory.class";
+  public static final String DEFAULT_DFS_CLIENT_XCEIVER_FACTORY_CLASS = "org.apache.hadoop.net.StandardSocketFactory";
+  
   // WebHDFS retry policy
   @Deprecated
   public static final String  DFS_HTTP_CLIENT_RETRY_POLICY_ENABLED_KEY =

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/RemotePeerFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/RemotePeerFactory.java
@@ -20,11 +20,9 @@ package org.apache.hadoop.hdfs;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdfs.net.Peer;
 
-import javax.net.SocketFactory;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
@@ -43,12 +41,4 @@ public interface RemotePeerFactory {
   Peer newConnectedPeer(InetSocketAddress addr,
       Token<BlockTokenIdentifier> blockToken, DatanodeID datanodeId)
       throws IOException;
-  
-  /**
-   * SocketFactory to be used to establish the connection
-   * @param conf
-   * @return appropriate socket factory
-   * @throws IOException
-   */
-  SocketFactory getSocketFactory(Configuration conf) throws IOException;
 }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NamenodeFsck.java
@@ -57,13 +57,11 @@ import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeDescriptor;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo;
 import org.apache.hadoop.hdfs.server.blockmanagement.NumberReplicas;
-import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
 import org.apache.hadoop.hdfs.util.LightWeightLinkedSet;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.NetworkTopology;
 import org.apache.hadoop.net.NodeBase;
-import org.apache.hadoop.net.StandardSocketFactory;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
@@ -86,16 +84,12 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdfs.RemotePeerFactory;
 import org.apache.hadoop.hdfs.net.Peer;
 import org.apache.hadoop.hdfs.net.TcpPeerServer;
-import org.apache.hadoop.hdfs.server.blockmanagement.NumberReplicas;
-import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
 
-import javax.net.SocketFactory;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.protocol.datatransfer.sasl.DataEncryptionKeyFactory;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.hdfs.security.token.block.DataEncryptionKey;
 import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager;
-import org.apache.hadoop.hdfs.server.blockmanagement.DatanodeStorageInfo;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.tracing.TraceUtils;
 import org.apache.htrace.core.Tracer;
@@ -973,16 +967,13 @@ public class NamenodeFsck implements DataEncryptionKeyFactory {
             setTracer(tracer).
             setRemotePeerFactory(new RemotePeerFactory() {
               @Override
-              public SocketFactory getSocketFactory(Configuration conf) throws IOException {
-                return new StandardSocketFactory();
-              }
-  
-              @Override
               public Peer newConnectedPeer(InetSocketAddress addr,
                   Token<BlockTokenIdentifier> blockToken, DatanodeID datanodeId)
                   throws IOException {
                 Peer peer = null;
-                Socket s = getSocketFactory(namenode.conf).createSocket();
+                Socket s = NetUtils.getSocketFactoryFromProperty(conf,
+                    conf.get(DFSConfigKeys.DFS_CLIENT_XCEIVER_SOCKET_FACTORY_CLASS_KEY,
+                        DFSConfigKeys.DEFAULT_DFS_CLIENT_XCEIVER_FACTORY_CLASS)).createSocket();
                 try {
                   s.connect(addr, HdfsServerConstants.READ_TIMEOUT);
                   s.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -2031,13 +2031,23 @@
     </description>
   </property>
 
-<property>
-  <name>dfs.namenode.list.encryption.zones.num.responses</name>
-  <value>100</value>
-  <description>When listing encryption zones, the maximum number of zones
-    that will be returned in a batch. Fetching the list incrementally in
-    batches improves namenode performance.
-  </description>
-</property>
+  <property>
+    <name>dfs.namenode.list.encryption.zones.num.responses</name>
+    <value>100</value>
+    <description>When listing encryption zones, the maximum number of zones
+      that will be returned in a batch. Fetching the list incrementally in
+      batches improves namenode performance.
+    </description>
+  </property>
+
+  <property>
+    <name>dfs.client.xceiver.socket.factory.class</name>
+    <value>org.apache.hadoop.net.StandardSocketFactory</value>
+    <description>Socket Factory implementation to use when DFSClient connects
+      to datanode's DataXceiver. When Hops TLS is enabled, DataXceiver Server
+      still creates a plain server socket, so the client should not use a
+      HopsSSLSocketFactory.
+    </description>
+  </property>
 
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BlockReaderTestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/BlockReaderTestUtil.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hdfs;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.shortcircuit.ShortCircuitShm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,7 +51,6 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 
-import javax.net.SocketFactory;
 import org.apache.hadoop.fs.FsTracer;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
@@ -200,16 +198,13 @@ public class BlockReaderTestUtil {
       setTracer(FsTracer.get(fs.getConf())).
       setRemotePeerFactory(new RemotePeerFactory() {
         @Override
-        public SocketFactory getSocketFactory(Configuration conf) throws IOException {
-          return NetUtils.getDefaultSocketFactory(conf);
-        }
-  
-        @Override
         public Peer newConnectedPeer(InetSocketAddress addr,
             Token<BlockTokenIdentifier> blockToken, DatanodeID datanodeId)
             throws IOException {
           Peer peer = null;
-          Socket sock = getSocketFactory(fs.getConf()).createSocket();
+          Socket sock = NetUtils.getSocketFactoryFromProperty(fs.getConf(),
+              fs.getConf().get(DFSConfigKeys.DFS_CLIENT_XCEIVER_SOCKET_FACTORY_CLASS_KEY,
+                  DFSConfigKeys.DEFAULT_DFS_CLIENT_XCEIVER_FACTORY_CLASS)).createSocket();
           try {
             sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
             sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSSSLServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSSSLServer.java
@@ -17,6 +17,8 @@ package org.apache.hadoop.hdfs;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -108,12 +110,19 @@ public class TestDFSSSLServer extends HopsSSLTestUtils {
     @Test
     public void testChecksum() throws Exception {
         LOG.debug("testChecksum");
+        Random rand = new Random();
+        byte[] data = new byte[6 * 1024];
+        rand.nextBytes(data);
         dfs1 = DistributedFileSystem.newInstance(conf);
         Path file = new Path("some_file");
-        dfs1.create(file);
+        FSDataOutputStream out = dfs1.create(file);
+        out.write(data);
+        out.hflush();
+        out.close();
         boolean exists = dfs1.exists(file);
         assertTrue(exists);
         FileChecksum checksum = dfs1.getFileChecksum(file);
+        Assert.assertNotNull(checksum);
         LOG.debug("File checksum is: " + checksum.toString());
     }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.hdfs.server.datanode.CachingStrategy;
 import org.apache.hadoop.io.IOUtils;
 import org.junit.Assert;
 
-import javax.net.SocketFactory;
 import org.apache.hadoop.fs.FsTracer;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 
@@ -169,16 +168,13 @@ public class TestBlockTokenWithDFS {
           setTracer(FsTracer.get(conf)).
           setRemotePeerFactory(new RemotePeerFactory() {
             @Override
-            public SocketFactory getSocketFactory(Configuration conf) throws IOException {
-              return NetUtils.getDefaultSocketFactory(conf);
-            }
-  
-            @Override
             public Peer newConnectedPeer(InetSocketAddress addr,
                 Token<BlockTokenIdentifier> blockToken, DatanodeID datanodeId)
                 throws IOException {
               Peer peer = null;
-              Socket sock = getSocketFactory(conf).createSocket();
+              Socket sock = NetUtils.getSocketFactoryFromProperty(conf,
+                  conf.get(DFSConfigKeys.DFS_CLIENT_XCEIVER_SOCKET_FACTORY_CLASS_KEY,
+                      DFSConfigKeys.DEFAULT_DFS_CLIENT_XCEIVER_FACTORY_CLASS)).createSocket();
               try {
                 sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
                 sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailure.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestDataNodeVolumeFailure.java
@@ -66,7 +66,6 @@ import org.apache.hadoop.hdfs.net.TcpPeerServer;
 import org.apache.hadoop.hdfs.server.protocol.BlockReport;
 import org.apache.hadoop.io.IOUtils;
 
-import javax.net.SocketFactory;
 import org.apache.hadoop.fs.FsTracer;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
@@ -445,16 +444,13 @@ public class TestDataNodeVolumeFailure {
       setTracer(FsTracer.get(conf)).
       setRemotePeerFactory(new RemotePeerFactory() {
         @Override
-        public SocketFactory getSocketFactory(Configuration conf) throws IOException {
-          return NetUtils.getDefaultSocketFactory(conf);
-        }
-  
-        @Override
         public Peer newConnectedPeer(InetSocketAddress addr,
             Token<BlockTokenIdentifier> blockToken, DatanodeID datanodeId)
             throws IOException {
           Peer peer = null;
-          Socket sock = getSocketFactory(conf).createSocket();
+          Socket sock = NetUtils.getSocketFactoryFromProperty(conf,
+              conf.get(DFSConfigKeys.DFS_CLIENT_XCEIVER_SOCKET_FACTORY_CLASS_KEY,
+                  DFSConfigKeys.DEFAULT_DFS_CLIENT_XCEIVER_FACTORY_CLASS)).createSocket();
           try {
             sock.connect(addr, HdfsServerConstants.READ_TIMEOUT);
             sock.setSoTimeout(HdfsServerConstants.READ_TIMEOUT);


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1525

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
There is a configuration property in DFSConfigKeys which specifies what Socket Factory to use when talking to DataNode's Xceiver server. It defaults to StandardSocketFactory as xceiver server does not communicate over TLS

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: