### PR TITLE
[HOPS-1550] IndividualBlockLock.announceBlockDoesNotExist should not use global blockId variable

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/lock/IndividualBlockLock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/io/hops/transaction/lock/IndividualBlockLock.java
@@ -45,9 +45,9 @@ class IndividualBlockLock extends BaseIndividualBlockLock {
     readBlock(blockId, inodeId);
   }
 
-  private void announceBlockDoesNotExist() throws TransactionContextException {
+  private void announceBlockDoesNotExist(long blkId, long inodeId) throws TransactionContextException {
     EntityManager.snapshotMaintenance
-        (HdfsTransactionContextMaintenanceCmds.BlockDoesNotExist, blockId, inodeId);
+        (HdfsTransactionContextMaintenanceCmds.BlockDoesNotExist, blkId, inodeId);
   }
 
   protected void announceEmptyFile(long inodeFileId) throws TransactionContextException {
@@ -64,7 +64,7 @@ class IndividualBlockLock extends BaseIndividualBlockLock {
       if (result != null) {
         blocks.add(result);
       } else {
-        announceBlockDoesNotExist();
+        announceBlockDoesNotExist(blkId, inodeId);
       }
     }
   }


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1550

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: