### PR TITLE
[HOPS-1552] DataNodes use Service Discovery to connect to NameNodes instead of static configuration file

### DIFF
--- a/hadoop-common-project/hadoop-common/pom.xml
+++ b/hadoop-common-project/hadoop-common/pom.xml
@@ -328,6 +328,11 @@
       <groupId>io.hops.gpu</groupId>
       <artifactId>hops-gpu-management</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.logicalclocks</groupId>
+      <artifactId>service-discovery-client</artifactId>
+      <version>${sd-client.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/net/ServiceDiscoveryClientFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/net/ServiceDiscoveryClientFactory.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.net;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.logicalclocks.servicediscoverclient.Builder;
+import com.logicalclocks.servicediscoverclient.ServiceDiscoveryClient;
+import com.logicalclocks.servicediscoverclient.exceptions.ServiceDiscoveryException;
+
+public class ServiceDiscoveryClientFactory {
+  
+  private static volatile ServiceDiscoveryClientFactory SELF;
+  private ServiceDiscoveryClient testClient;
+  
+  private ServiceDiscoveryClientFactory() {
+  }
+  
+  public static ServiceDiscoveryClientFactory getInstance() {
+    if (SELF == null) {
+      synchronized (ServiceDiscoveryClientFactory.class) {
+        if (SELF == null) {
+          SELF = new ServiceDiscoveryClientFactory();
+        }
+      }
+    }
+    return SELF;
+  }
+  
+  public ServiceDiscoveryClient getClient(Builder builder) throws ServiceDiscoveryException {
+    return testClient != null ? testClient : builder.build();
+  }
+  
+  @VisibleForTesting
+  public void setClient(ServiceDiscoveryClient sdClient) {
+    testClient = sdClient;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -833,5 +833,17 @@ public class CommonConfigurationKeysPublic {
   public static final String DEFAULT_JWT_MANAGER_SERVICE_INVALIDATE_PATH = "/hopsworks-api/api/jwt/service";
   public static final String JWT_MANAGER_SERVICE_INVALIDATE_PATH = ServiceJWTManager.JWT_MANAGER_PREFIX
       + "service-invalidate-path";
+  
+  // Service Discovery (Consul) properties
+  private static final String SERVICE_DISCOVERY_PREFIX = HOPS_PREFIX + "service-discovery.";
+  
+  public static final String SERVICE_DISCOVERY_ENABLED_KEY = SERVICE_DISCOVERY_PREFIX + "enabled";
+  public static final boolean DEFAULT_SERVICE_DISCOVERY_ENABLED = false;
+  
+  public static final String SERVICE_DISCOVERY_DNS_HOST = SERVICE_DISCOVERY_PREFIX + "dns-host";
+  public static final String DEFAULT_SERVICE_DISCOVERY_DNS_HOST = "127.0.0.1";
+  
+  public static final String SERVICE_DISCOVERY_DNS_PORT = SERVICE_DISCOVERY_PREFIX + "dns-port";
+  public static final int DEFAULT_SERVICE_DISCOVERY_DNS_PORT = 53;
 }
 

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -2549,4 +2549,22 @@
       invalidate master token.
     </description>
   </property>
+
+  <property>
+    <name>hops.service-discovery.enabled</name>
+    <value>false</value>
+    <description>Flag to get NameNode RPC addresses from Service Discovery instead of configuration file.</description>
+  </property>
+
+  <property>
+    <name>hops.service-discovery.dns-host</name>
+    <value>127.0.0.1</value>
+    <description>IP address of the DNS server used to resolve service discovery domains.</description>
+  </property>
+
+  <property>
+    <name>hops.service-discovery.dns-port</name>
+    <value>53</value>
+    <description>Port of the DNS server used to resolve service discovery domains.</description>
+  </property>
 </configuration>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdfs;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_ADMIN;
 import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_CLIENT_HTTPS_NEED_AUTH_DEFAULT;
@@ -44,6 +45,13 @@ import java.util.Random;
 import java.util.Set;
 
 
+import com.logicalclocks.servicediscoverclient.Builder;
+import com.logicalclocks.servicediscoverclient.ServiceDiscoveryClient;
+import com.logicalclocks.servicediscoverclient.exceptions.ServiceDiscoveryException;
+import com.logicalclocks.servicediscoverclient.resolvers.Type;
+import com.logicalclocks.servicediscoverclient.service.Service;
+import com.logicalclocks.servicediscoverclient.service.ServiceQuery;
+import io.hops.net.ServiceDiscoveryClientFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Option;
@@ -57,23 +65,17 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.crypto.key.KeyProviderFactory;
-import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.protocol.ClientDatanodeProtocol;
 import org.apache.hadoop.hdfs.protocol.DatanodeID;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
-import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.hdfs.protocolPB.ClientDatanodeProtocolTranslatorPB;
-import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.net.NodeBase;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.ToolRunner;
 
 import javax.net.SocketFactory;
@@ -90,7 +92,7 @@ import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 
 import static org.apache.hadoop.hdfs.DFSConfigKeys.*;
-import org.apache.hadoop.hdfs.server.namenode.FSDirectory;
+
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpServer3;
 import org.apache.hadoop.security.SecurityUtil;
@@ -101,6 +103,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.protobuf.BlockingService;
 import java.net.InetAddress;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @InterfaceAudience.Private
 public class DFSUtil {
@@ -703,6 +707,10 @@ public class DFSUtil {
     List<InetSocketAddress> addresses = getNameNodesRPCAddresses(conf,
         DFSConfigKeys.DFS_NAMENODES_SERVICE_RPC_ADDRESS_KEY, DFS_NAMENODES_RPC_ADDRESS_KEY,
         DFS_NAMENODE_SERVICE_RPC_ADDRESS_KEY, DFS_NAMENODE_RPC_ADDRESS_KEY);
+    if (addresses.isEmpty() && conf.getBoolean(SERVICE_DISCOVERY_ENABLED_KEY, DEFAULT_SERVICE_DISCOVERY_ENABLED)) {
+      throw new IOException("Could not resolve Namenode RPC address and Service Discovery is *enabled*. Check your " +
+          "configuration");
+    }
     if (addresses.isEmpty()) {
       addresses = getNameNodesRPCAddresses(conf);
     }
@@ -758,14 +766,21 @@ public class DFSUtil {
   private static List<URI> getNameNodesRPCAddressesAsURIs(Configuration conf,
       String listKey, String defaultListKey, String singleKey, String defaultSingleKey) {
     List<URI> uris = new ArrayList<>();
-    for (String nn : getNameNodesRPCAddressesInternal(conf, listKey,
-        singleKey)) {
-      uris.add(DFSUtil.createHDFSUri(nn));
-    }
-    if(uris.isEmpty()){
-     for (String nn : getNameNodesRPCAddressesInternal(conf, defaultListKey, defaultSingleKey)) {
-      uris.add(DFSUtil.createHDFSUri(nn));
-      } 
+    
+    if (conf.getBoolean(SERVICE_DISCOVERY_ENABLED_KEY, DEFAULT_SERVICE_DISCOVERY_ENABLED)) {
+      for (String nn : getNameNodesRPCAddressesFromServiceDiscovery(conf)) {
+        uris.add(DFSUtil.createHDFSUri(nn));
+      }
+    } else {
+      for (String nn : getNameNodesRPCAddressesInternal(conf, listKey,
+          singleKey)) {
+        uris.add(DFSUtil.createHDFSUri(nn));
+      }
+      if (uris.isEmpty()) {
+        for (String nn : getNameNodesRPCAddressesInternal(conf, defaultListKey, defaultSingleKey)) {
+          uris.add(DFSUtil.createHDFSUri(nn));
+        }
+      }
     }
     return uris;
   }
@@ -782,7 +797,44 @@ public class DFSUtil {
   public static String joinNameNodesHostPortString(List<String> namenodes) {
     return Joiner.on(",").join(namenodes);
   }
-
+  
+  private static Set<String> getNameNodesRPCAddressesFromServiceDiscovery(Configuration conf) {
+    // Try with rpc-addresses
+    String nnAddress = null;
+    Set<String> nns = getNameNodesRPCAddressesInternal(conf, DFS_NAMENODES_RPC_ADDRESS_KEY, "dont.want.single.key");
+    if (nns != null && !nns.isEmpty()) {
+      nnAddress = nns.iterator().next();
+    } else {
+      // And fallback to defaultFS
+      nnAddress = conf.get(DFSConfigKeys.FS_DEFAULT_NAME_KEY);
+    }
+    if (!Strings.isNullOrEmpty(nnAddress)) {
+      ServiceDiscoveryClient client = null;
+      final URI defaultFS = createHDFSUri(nnAddress);
+      try {
+        Builder sdBuilder = new Builder(Type.DNS)
+            .withDnsHost(conf.get(SERVICE_DISCOVERY_DNS_HOST, DEFAULT_SERVICE_DISCOVERY_DNS_HOST))
+            .withDnsPort(conf.getInt(SERVICE_DISCOVERY_DNS_PORT, DEFAULT_SERVICE_DISCOVERY_DNS_PORT));
+        client = ServiceDiscoveryClientFactory.getInstance().getClient(sdBuilder);
+        return client.getService(
+            ServiceQuery.of(defaultFS.getHost(), Collections.<String>emptySet()))
+            .collect(Collectors.mapping(new Function<Service, String>() {
+              @Override
+              public String apply(Service service) {
+                return service.getAddress() + ":" + defaultFS.getPort();
+              }
+            }, Collectors.<String>toSet()));
+      } catch (ServiceDiscoveryException ex) {
+        LOG.warn("Could not resolve Service", ex);
+      } finally {
+        if (client != null) {
+          client.close();
+        }
+      }
+    }
+    return Collections.emptySet();
+  }
+  
   private static Set<String> getNameNodesRPCAddressesInternal(
       Configuration conf, String listKey, String singleKey) {
     String namenodes = conf.get(listKey);

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     
     <curator.version>2.7.1</curator.version>
     <hamcrest.version>1.3</hamcrest.version>
+    <sd-client.version>0.3</sd-client.version>
     
         <!-- maven plugin versions -->
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1552

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature

* **What is the new behavior (if this is a feature change)?**
When Service Discovery is enabled we get NameNodes' RPC addresses from service discovery instead of the configuration file.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change

* **Other information**: