### PR TITLE
[HOPS-1551] System users x.509 v2

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/CertificateLocalization.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/CertificateLocalization.java
@@ -69,4 +69,6 @@ public interface CertificateLocalization {
   String getSuperTruststoreLocation();
   
   String getSuperTruststorePass();
+  
+  String getSuperMaterialPasswordFile();
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsFileBasedKeyStoresFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsFileBasedKeyStoresFactory.java
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.security;
+
+import com.google.common.base.Strings;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.net.HopsSSLSocketFactory;
+import org.apache.hadoop.net.hopssslchecks.HopsSSLCryptoMaterial;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory;
+import org.apache.hadoop.security.ssl.KeyStoresFactory;
+import org.apache.hadoop.security.ssl.ReloadingX509KeyManager;
+import org.apache.hadoop.security.ssl.ReloadingX509TrustManager;
+import org.apache.hadoop.security.ssl.SSLFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.DEFAULT_SSL_KEYSTORE_RELOAD_INTERVAL;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.DEFAULT_SSL_KEYSTORE_RELOAD_TIMEUNIT;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.DEFAULT_SSL_TRUSTSTORE_RELOAD_INTERVAL;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_KEYSTORE_KEYPASSWORD_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_KEYSTORE_LOCATION_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_KEYSTORE_PASSWORD_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_PASSWORDFILE_LOCATION_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY;
+import static org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory.SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY;
+
+public class HopsFileBasedKeyStoresFactory implements KeyStoresFactory {
+  private static final Log LOG = LogFactory.getLog(HopsFileBasedKeyStoresFactory.class);
+  
+  private Configuration sslConf;
+  private Configuration systemConf;
+  private ReloadingX509KeyManager keyManager;
+  private KeyManager[] keyManagers;
+  private ReloadingX509TrustManager trustManager;
+  private TrustManager[] trustManagers;
+  
+  @Override
+  public void init(SSLFactory.Mode mode) throws IOException, GeneralSecurityException {
+    HopsSSLCryptoMaterial material = loadCryptoMaterial(mode);
+    createKeyManagers(mode, material);
+    createTrustManagers(mode, material);
+  }
+  
+  public HopsSSLCryptoMaterial loadCryptoMaterial(SSLFactory.Mode mode) throws IOException {
+    try {
+      CertificateLocalizationCtx certificateLocalizationCtx = CertificateLocalizationCtx.getInstance();
+      certificateLocalizationCtx.setProxySuperusers(systemConf);
+      Configuration x509MaterialConf = new Configuration(false);
+      x509MaterialConf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY,
+          systemConf.get(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, ""));
+      // Create a HopsSSLSocketFactory to use its functionality of identifying the correct security material
+      // We don't use the socket factory anywhere else in this class
+      HopsSSLSocketFactory hopsSSLSocketFactory = new HopsSSLSocketFactory();
+      hopsSSLSocketFactory.setConf(x509MaterialConf);
+      return hopsSSLSocketFactory.configureCryptoMaterial(
+          certificateLocalizationCtx.getCertificateLocalization(), certificateLocalizationCtx.getProxySuperusers());
+    } catch (Exception ex) {
+      UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
+      LOG.warn("Could not locate cryptographic material for <" + currentUser.getUserName()
+        + "> Falling back to ssl-{client,server}.xml");
+      // Fallback to old-school ssl-{client,server}.xml
+      String keystoreLocationProperty = FileBasedKeyStoresFactory.resolvePropertyName(mode,
+          SSL_KEYSTORE_LOCATION_TPL_KEY);
+      String keystoreLocation = sslConf.get(keystoreLocationProperty);
+      String keystorePasswordProperty = FileBasedKeyStoresFactory.resolvePropertyName(mode,
+          SSL_KEYSTORE_PASSWORD_TPL_KEY);
+      String keystorePassword = sslConf.get(keystorePasswordProperty);
+      String keyPasswordProperty =
+          FileBasedKeyStoresFactory.resolvePropertyName(mode, SSL_KEYSTORE_KEYPASSWORD_TPL_KEY);
+      String keyPassword = sslConf.get(keyPasswordProperty, keystorePassword);
+      
+      String truststoreLocationProperty = FileBasedKeyStoresFactory.resolvePropertyName(mode,
+          SSL_TRUSTSTORE_LOCATION_TPL_KEY);
+      String truststoreLocation = sslConf.get(truststoreLocationProperty);
+      String passwordFileLocationProperty =
+          FileBasedKeyStoresFactory.resolvePropertyName(mode,
+              SSL_PASSWORDFILE_LOCATION_TPL_KEY);
+      String passwordFileLocation = sslConf.get(passwordFileLocationProperty, null);
+      if (Strings.isNullOrEmpty(keystoreLocation) || Strings.isNullOrEmpty(truststoreLocation)
+        || Strings.isNullOrEmpty(keystorePassword) || Strings.isNullOrEmpty(keyPassword)) {
+        throw new IOException("Failed to determine cryptographic material for user <" + currentUser.getUserName()
+          + ">. Exhausted all methods!");
+      }
+      return new HopsSSLCryptoMaterial(
+          keystoreLocation, keystorePassword, keyPassword,
+          truststoreLocation, keystorePassword,
+          passwordFileLocation, true);
+    }
+  }
+  
+  @Override
+  public void destroy() {
+    if (trustManager != null) {
+      trustManager.destroy();
+      trustManager = null;
+      trustManagers = null;
+    }
+    if (keyManager != null) {
+      keyManager.stop();
+      keyManager = null;
+      keyManagers = null;
+    }
+  }
+  
+  @Override
+  public KeyManager[] getKeyManagers() {
+    return keyManagers;
+  }
+  
+  @Override
+  public TrustManager[] getTrustManagers() {
+    return trustManagers;
+  }
+  
+  @Override
+  public void setConf(Configuration conf) {
+    this.sslConf = conf;
+  }
+  
+  @Override
+  public Configuration getConf() {
+    return sslConf;
+  }
+  
+  public void setSystemConf(Configuration conf) {
+    this.systemConf = conf;
+  }
+  
+  public Configuration getSystemConf() {
+    return systemConf;
+  }
+  
+  private void createKeyManagers(SSLFactory.Mode mode, HopsSSLCryptoMaterial material)
+      throws IOException, GeneralSecurityException {
+    boolean requireClientCert = sslConf.getBoolean(SSLFactory.SSL_REQUIRE_CLIENT_CERT_KEY,
+        SSLFactory.SSL_REQUIRE_CLIENT_CERT_DEFAULT);
+    
+    String keystoreType = sslConf.get(
+        FileBasedKeyStoresFactory.resolvePropertyName(mode, FileBasedKeyStoresFactory.SSL_KEYSTORE_TYPE_TPL_KEY),
+        FileBasedKeyStoresFactory.DEFAULT_KEYSTORE_TYPE);
+    
+    if (requireClientCert || mode == SSLFactory.Mode.SERVER) {
+      
+      String keystoreLocation = material.getKeyStoreLocation();
+      if (Strings.isNullOrEmpty(keystoreLocation)) {
+        throw new GeneralSecurityException("Could not identify correct keystore");
+      }
+      String keystorePassword = material.getKeyStorePassword();
+      if (Strings.isNullOrEmpty(keystorePassword)) {
+        throw new GeneralSecurityException("Could not load keystore password");
+      }
+      String keyPassword = material.getKeyPassword();
+      if (Strings.isNullOrEmpty(keyPassword)) {
+        throw new GeneralSecurityException("Could not load key password");
+      }
+  
+      long keyStoreReloadInterval = sslConf.getLong(
+          FileBasedKeyStoresFactory.resolvePropertyName(mode, SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY),
+          DEFAULT_SSL_KEYSTORE_RELOAD_INTERVAL);
+      String timeUnitStr = sslConf.get(
+          FileBasedKeyStoresFactory.resolvePropertyName(mode, SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY),
+          DEFAULT_SSL_KEYSTORE_RELOAD_TIMEUNIT);
+      TimeUnit reloadTimeUnit = TimeUnit.valueOf(timeUnitStr.toUpperCase());
+      
+      String passwordFileLocation = material.getPasswordFileLocation();
+      keyManager = new ReloadingX509KeyManager(keystoreType, keystoreLocation, keystorePassword, passwordFileLocation,
+          keyPassword, keyStoreReloadInterval, reloadTimeUnit);
+      
+      keyManager.init();
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(mode.toString() + " Loaded KeyStore: " + keystoreLocation);
+      }
+      keyManagers = new KeyManager[]{keyManager};
+    } else {
+      KeyStore keyStore = KeyStore.getInstance(keystoreType);
+      keyStore.load(null, null);
+      KeyManagerFactory keyMgrFactory = KeyManagerFactory.getInstance(SSLFactory.SSLCERTIFICATE);
+      keyMgrFactory.init(keyStore, null);
+      keyManagers = keyMgrFactory.getKeyManagers();
+    }
+  }
+  
+  private void createTrustManagers(SSLFactory.Mode mode, HopsSSLCryptoMaterial material)
+      throws IOException, GeneralSecurityException {
+    String truststoreType = sslConf.get(
+        FileBasedKeyStoresFactory.resolvePropertyName(mode, FileBasedKeyStoresFactory.SSL_TRUSTSTORE_TYPE_TPL_KEY),
+        FileBasedKeyStoresFactory.DEFAULT_KEYSTORE_TYPE);
+    String truststoreLocation = material.getTrustStoreLocation();
+    if (Strings.isNullOrEmpty(truststoreLocation)) {
+      throw new GeneralSecurityException("Could not identify correct truststore");
+    }
+    String truststorePassword = material.getTrustStorePassword();
+    if (Strings.isNullOrEmpty(truststorePassword)) {
+      throw new GeneralSecurityException("Could not load truststore password");
+    }
+    String passwordFileLocation = material.getPasswordFileLocation();
+    long truststoreReloadInterval =
+        sslConf.getLong(
+            FileBasedKeyStoresFactory.resolvePropertyName(mode, SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY),
+            DEFAULT_SSL_TRUSTSTORE_RELOAD_INTERVAL);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(mode.toString() + " TrustStore: " + truststoreLocation);
+    }
+    trustManager = new ReloadingX509TrustManager(truststoreType,
+        truststoreLocation, truststorePassword, passwordFileLocation, truststoreReloadInterval);
+    trustManager.init();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(mode.toString() + " Loaded TrustStore: " + truststoreLocation);
+    }
+    trustManagers = new TrustManager[]{trustManager};
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/SuperuserKeystoresLoader.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/SuperuserKeystoresLoader.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.security;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.ssl.X509SecurityMaterial;
+import org.apache.hadoop.util.envVars.EnvironmentVariables;
+import org.apache.hadoop.util.envVars.EnvironmentVariablesFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SuperuserKeystoresLoader {
+  private final static Log LOG = LogFactory.getLog(SuperuserKeystoresLoader.class);
+  
+  public static final String SUPER_MATERIAL_DIRECTORY_ENV_VARIABLE = "SUPERUSER_MATERIAL_DIRECTORY";
+  protected static final String SUPER_MATERIAL_HOME_SUBDIRECTORY = ".hops_tls";
+  
+  private static final String SUPER_KEYSTORE_FILE_FORMAT = "%s__kstore.jks";
+  private static final String SUPER_TRUSTSTORE_FILE_FORMAT = "%s__tstore.jks";
+  private static final String SUPER_MATERIAL_PASSWD_FILE_FORMAT = "%s__passwd";
+  private static final Pattern HOME_PATTERN = Pattern.compile(".*\\$\\{HOME\\}.*");
+  private static final Pattern HOME_REPLACEMENT_PATTERN = Pattern.compile("\\$\\{HOME\\}");
+  private static final Pattern USER_PATTERN = Pattern.compile(".*\\$\\{USER\\}.*");
+  private static final Pattern USER_REPLACEMENT_PATTERN = Pattern.compile("\\$\\{USER\\}");
+  
+  private final Configuration configuration;
+  private final EnvironmentVariables environmentVariables;
+  
+  public SuperuserKeystoresLoader(Configuration configuration) {
+    this.configuration = configuration;
+    this.environmentVariables = EnvironmentVariablesFactory.getInstance();
+  }
+  
+  public X509SecurityMaterial loadSuperUserMaterial() throws IOException {
+    Path superMaterialDirectory = getMaterialDirectory();
+    String username = UserGroupInformation.getCurrentUser().getUserName();
+    Path keystore = superMaterialDirectory.resolve(getSuperKeystoreFilename(username));
+    Path truststore = superMaterialDirectory.resolve(getSuperTruststoreFilename(username));
+    Path password = superMaterialDirectory.resolve(getSuperMaterialPasswdFilename(username));
+    return new X509SecurityMaterial(keystore, truststore, password);
+  }
+  
+  private Path getMaterialDirectory() throws IOException {
+    // First start with environment variable
+    String superuserMaterialDirectory = environmentVariables.getEnv(SUPER_MATERIAL_DIRECTORY_ENV_VARIABLE);
+    if (superuserMaterialDirectory != null) {
+      LOG.debug("Found environment variable for super user material directory. Path is " + superuserMaterialDirectory);
+      return Paths.get(superuserMaterialDirectory);
+    }
+    
+    // Then check if there is a configured superuser material directory
+    String userHome = System.getProperty("user.home");
+    superuserMaterialDirectory = configuration.get(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, null);
+    if (!Strings.isNullOrEmpty(superuserMaterialDirectory)) {
+      LOG.debug("Super user material directory has been set in configuration file " + superuserMaterialDirectory);
+      // If the property has ${HOME} it will be substituted my user's home directory
+      Matcher matcher = HOME_PATTERN.matcher(superuserMaterialDirectory);
+      if (matcher.matches()) {
+        matcher = HOME_REPLACEMENT_PATTERN.matcher(superuserMaterialDirectory);
+        String templatedDirectory = matcher.replaceAll(userHome);
+        LOG.debug("Replacing ${HOME} - Super user material directory: " + templatedDirectory);
+        return Paths.get(templatedDirectory);
+      }
+      matcher = USER_PATTERN.matcher(superuserMaterialDirectory);
+      if (matcher.matches()) {
+        matcher = USER_REPLACEMENT_PATTERN.matcher(superuserMaterialDirectory);
+        String templatedDirectory = matcher.replaceAll(UserGroupInformation.getCurrentUser().getUserName());
+        LOG.debug("Replacing ${USER} - Super user material directory: " + templatedDirectory);
+        return Paths.get(templatedDirectory);
+      }
+      return Paths.get(superuserMaterialDirectory);
+    }
+    
+    // Finally fallback to user's $HOME
+    Path path = Paths.get(userHome, SUPER_MATERIAL_HOME_SUBDIRECTORY);
+    LOG.debug("Falling back to $HOME for super user material directory: " + path);
+    return path;
+  }
+  
+  @VisibleForTesting
+  public String getSuperKeystoreFilename(String username) {
+    return String.format(SUPER_KEYSTORE_FILE_FORMAT, username);
+  }
+  
+  @VisibleForTesting
+  public String getSuperTruststoreFilename(String username) {
+    return String.format(SUPER_TRUSTSTORE_FILE_FORMAT, username);
+  }
+  
+  @VisibleForTesting
+  public String getSuperMaterialPasswdFilename(String username) {
+    return String.format(SUPER_MATERIAL_PASSWD_FILE_FORMAT, username);
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/KMSClientProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/crypto/key/kms/KMSClientProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.crypto.key.kms;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
@@ -244,7 +245,7 @@ public class KMSClientProvider extends KeyProvider implements CryptoExtension,
   public static class KMSEncryptedKeyVersion extends EncryptedKeyVersion {
     public KMSEncryptedKeyVersion(String keyName, String keyVersionName,
         byte[] iv, String encryptedVersionName, byte[] keyMaterial) {
-      super(keyName, keyVersionName, iv, new KMSKeyVersion(null, 
+      super(keyName, keyVersionName, iv, new KMSKeyVersion(null,
           encryptedVersionName, keyMaterial));
     }
   }
@@ -386,6 +387,10 @@ public class KMSClientProvider extends KeyProvider implements CryptoExtension,
     canonicalService = SecurityUtil.buildTokenService(serviceUri);
 
     if ("https".equalsIgnoreCase(kmsUrl.getProtocol())) {
+      if (conf.getBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED,
+              CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT)) {
+        conf.set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
+      }
       sslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
       try {
         sslFactory.init();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -475,6 +475,9 @@ public class CommonConfigurationKeysPublic {
   public static final String HOPS_CRL_VALIDATION_ENABLED_KEY = HOPS_CRL_PREFIX + "validation.enabled";
   public static final boolean HOPS_CRL_VALIDATION_ENABLED_DEFAULT = false;
   
+  private static final String HOPS_TLS_PREFIX = HOPS_PREFIX + "tls.";
+  public static final String HOPS_TLS_SUPER_MATERIAL_DIRECTORY = HOPS_TLS_PREFIX + "superuser-material-directory";
+  
   /**
    * Certificate Revocation List fetcher class
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Server.java
@@ -70,6 +70,7 @@ import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import io.hops.security.HopsX509AuthenticationException;
 import io.hops.security.HopsX509Authenticator;
 import io.hops.security.HopsX509AuthenticatorFactory;
@@ -3071,6 +3072,8 @@ public abstract class Server {
             CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT);
 
     if (this.isHopsTLSEnabled) {
+      // Set custom keystores factory
+      conf.set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
       // Configure SSLContext
       this.sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
       try {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/HopsSSLSocketFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/HopsSSLSocketFactory.java
@@ -179,7 +179,7 @@ public class HopsSSLSocketFactory extends SocketFactory implements Configurable 
     sslClientConf.addResource(sslConfResource);
   }
   
-  public void configureCryptoMaterial(CertificateLocalization certificateLocalization, Set<String> proxySuperusers)
+  public HopsSSLCryptoMaterial configureCryptoMaterial(CertificateLocalization certificateLocalization, Set<String> proxySuperusers)
       throws SSLCertificateException {
     
     UserGroupInformation currentUser = null;
@@ -219,6 +219,7 @@ public class HopsSSLSocketFactory extends SocketFactory implements Configurable 
         LOG.debug("Finally, the keystore that is used is: " + keyStoreFilePath);
       }
       conf.setBoolean(FORCE_CONFIGURE, false);
+      return configuredCryptoMaterial;
     } catch (IOException ex) {
       String user = currentUser != null ? currentUser.getUserName() : "Could not find user from UGI";
       LOG.error("Error while configuring SocketFactory for user <" + user + "> " + ex.getMessage(), ex);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/AbstractHopsSSLCheck.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/AbstractHopsSSLCheck.java
@@ -21,10 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.net.HopsSSLSocketFactory;
 import org.apache.hadoop.security.UserGroupInformation;
 import io.hops.security.CertificateLocalization;
-import org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory;
-import org.apache.hadoop.security.ssl.SSLFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
@@ -77,45 +74,6 @@ public abstract class AbstractHopsSSLCheck implements HopsSSLCheck, Comparable<H
       throw new SSLMaterialAlreadyConfiguredException("Crypto material for user <" + username + "> has already been" +
           " configured");
     }
-  }
-  
-  /**
-   * Reads cryptographic material configuration from ssl-server.xml
-   * @param configuration Hadoop configuration
-   * @return HopsSSLCryptoMaterial object with the values read from ssl-server.xml
-   * @throws IOException
-   */
-  protected HopsSSLCryptoMaterial readSuperuserMaterialFromFile(Configuration configuration) throws IOException {
-    Configuration sslConf = new Configuration(false);
-    String sslConfResource = configuration.get(SSLFactory.SSL_SERVER_CONF_KEY, "ssl-server.xml");
-  
-    sslConf.addResource(sslConfResource);
-  
-    String keystoreLocation = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_KEYSTORE_LOCATION_TPL_KEY));
-    String keystorePassword = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_KEYSTORE_PASSWORD_TPL_KEY));
-    String keyPassword = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_KEYSTORE_KEYPASSWORD_TPL_KEY));
-    String truststoreLocation = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY));
-    String truststorePassword = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY));
-  
-    File keystoreFd = new File(keystoreLocation);
-    File truststoreFd = new File(truststoreLocation);
-    if (!keystoreFd.exists() || !truststoreFd.exists()) {
-      throw new IOException("Keystore or Truststore specified in " + sslConfResource + " does not exist! " +
-          "Check your configuration.");
-    }
-  
-    return new HopsSSLCryptoMaterial(keystoreLocation, keystorePassword, keyPassword, truststoreLocation,
-        truststorePassword);
   }
   
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/EnvVariableHopsSSLCheck.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/EnvVariableHopsSSLCheck.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.net.hopssslchecks;
 
 import io.hops.security.HopsUtil;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.net.HopsSSLSocketFactory;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -34,6 +36,8 @@ import java.util.Set;
  * HopsSSLSocketFactory.CRYPTO_MATERIAL_ENV_VAR
  */
 public class EnvVariableHopsSSLCheck extends AbstractHopsSSLCheck {
+  private static final Log LOG = LogFactory.getLog(EnvVariableHopsSSLCheck.class);
+  
   public EnvVariableHopsSSLCheck() {
     super(110);
   }
@@ -51,8 +55,10 @@ public class EnvVariableHopsSSLCheck extends AbstractHopsSSLCheck {
       File trustStoreFd = Paths.get(cryptoMaterialDir, username + HopsSSLSocketFactory.TRUSTSTORE_SUFFIX).toFile();
       File passwordFd = Paths.get(cryptoMaterialDir, username + HopsSSLSocketFactory.PASSWD_FILE_SUFFIX).toFile();
       
-      if (!keystoreFd.exists() || !trustStoreFd.exists()) {
-        throw new IOException("Crypto material for user <" + username + "> could not be found in " + cryptoMaterialDir);
+      if (!keystoreFd.exists() || !trustStoreFd.exists() || !passwordFd.exists()) {
+        LOG.warn("Environment variable " + HopsSSLSocketFactory.CRYPTO_MATERIAL_ENV_VAR + " has been set to "
+          + cryptoMaterialDir + " but could not find material for user <" + username + ">");
+        return null;
       }
       
       String password = HopsUtil.readCryptoMaterialPassword(passwordFd);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/SuperUserHopsSSLCheck.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/net/hopssslchecks/SuperUserHopsSSLCheck.java
@@ -17,14 +17,19 @@
  */
 package org.apache.hadoop.net.hopssslchecks;
 
+import io.hops.security.HopsUtil;
+import io.hops.security.SuperuserKeystoresLoader;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.net.HopsSSLSocketFactory;
 import org.apache.hadoop.security.UserGroupInformation;
 import io.hops.security.CertificateLocalization;
+import org.apache.hadoop.security.ssl.X509SecurityMaterial;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Set;
 
 /**
@@ -67,16 +72,40 @@ public class SuperUserHopsSSLCheck extends AbstractHopsSSLCheck {
             certificateLocalization.getSuperKeystorePass(),
             certificateLocalization.getSuperKeyPassword(),
             certificateLocalization.getSuperTruststoreLocation(),
-            certificateLocalization.getSuperTruststorePass());
+            certificateLocalization.getSuperTruststorePass(),
+            certificateLocalization.getSuperMaterialPasswordFile(), true);
       }
     
       if (LOG.isDebugEnabled()) {
         LOG.debug("*** Called setTlsConfiguration for superuser but CertificateLocalization is NULL");
       }
     
-      return readSuperuserMaterialFromFile(configuration);
+      return getSuperuserMaterialFromFile(configuration);
     }
   
     return null;
+  }
+  
+  private HopsSSLCryptoMaterial getSuperuserMaterialFromFile(Configuration conf) throws IOException {
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    X509SecurityMaterial material = loader.loadSuperUserMaterial();
+    if (!fileExists(material.getKeyStoreLocation()) || !fileExists(material.getTrustStoreLocation())
+      || !fileExists(material.getPasswdLocation())) {
+      throw new IOException("Could not load Keystore/Truststore/Password file from "
+          + material.getKeyStoreLocation().getParent() + " . Check your permissions or configuration");
+    }
+    String password = HopsUtil.readCryptoMaterialPassword(material.getPasswdLocation().toFile());
+    return new HopsSSLCryptoMaterial(
+        material.getKeyStoreLocation().toString(),
+        password,
+        password,
+        material.getTrustStoreLocation().toString(),
+        password,
+        material.getPasswdLocation().toString(),
+        true);
+  }
+  
+  private boolean fileExists(Path path2file) {
+    return path2file.toFile().exists();
   }
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/ReloadingX509KeyManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/ReloadingX509KeyManager.java
@@ -238,7 +238,7 @@ public class ReloadingX509KeyManager extends X509ExtendedKeyManager {
     String keyStorePass;
     String keyPass;
     if (passwordFileLocation != null) {
-      keyStorePass = FileUtils.readFileToString(passwordFileLocation);
+      keyStorePass = FileUtils.readFileToString(passwordFileLocation).trim();
       keyPass = keyStorePass;
     } else {
       keyStorePass = keystorePassword;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/ReloadingX509TrustManager.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/ReloadingX509TrustManager.java
@@ -219,7 +219,7 @@ public final class ReloadingX509TrustManager
     KeyStore ks = KeyStore.getInstance(type);
     String tstorePassword;
     if (passwordFileLocation != null) {
-      tstorePassword = FileUtils.readFileToString(passwordFileLocation);
+      tstorePassword = FileUtils.readFileToString(passwordFileLocation).trim();
     } else {
       tstorePassword = password;
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLFactory.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/SSLFactory.java
@@ -17,6 +17,7 @@
 */
 package org.apache.hadoop.security.ssl;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -143,6 +144,9 @@ public class SSLFactory implements ConnectionConfigurator {
       = conf.getClass(KEYSTORES_FACTORY_CLASS_KEY,
                       FileBasedKeyStoresFactory.class, KeyStoresFactory.class);
     keystoresFactory = ReflectionUtils.newInstance(klass, sslConf);
+    if (keystoresFactory instanceof HopsFileBasedKeyStoresFactory) {
+      ((HopsFileBasedKeyStoresFactory)keystoresFactory).setSystemConf(conf);
+    }
 
     enabledProtocols = conf.getStrings(SSL_ENABLED_PROTOCOLS_KEY,
         SSL_ENABLED_PROTOCOLS_DEFAULT);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/X509SecurityMaterial.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/ssl/X509SecurityMaterial.java
@@ -21,6 +21,8 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
 public final class X509SecurityMaterial extends SecurityMaterial {
+  private final static ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+  
   private final Path keyStoreLocation;
   private final int keyStoreSize;
   private final Path trustStoreLocation;
@@ -44,6 +46,11 @@ public final class X509SecurityMaterial extends SecurityMaterial {
     this.keyStorePass = kStorePass;
     this.trustStoreMem = tstore;
     this.trustStorePass = tstorePass;
+  }
+  
+  public X509SecurityMaterial(Path keyStoreLocation, Path trustStoreLocation, Path passwdLocation) {
+    this(null, keyStoreLocation, trustStoreLocation, passwdLocation, EMPTY_BUFFER, null,
+        EMPTY_BUFFER, null);
   }
   
   public Path getKeyStoreLocation() {

--- a/hadoop-common-project/hadoop-common/src/test/java/io/hops/security/MockEnvironmentVariablesService.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/io/hops/security/MockEnvironmentVariablesService.java
@@ -15,21 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.util.envVars;
+package io.hops.security;
 
+import org.apache.hadoop.util.envVars.EnvironmentVariables;
+
+import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Read system environment variables
- */
-public class SystemEnvironmentVariables implements EnvironmentVariables {
-  private final Map<String, String> environmentVariables;
-  
-  public SystemEnvironmentVariables() {
-    environmentVariables = System.getenv();
+public class MockEnvironmentVariablesService implements EnvironmentVariables {
+  private final Map<String, String> mockEnvVars;
+
+  public MockEnvironmentVariablesService() {
+    mockEnvVars = new HashMap<>();
   }
-  
-  public String getEnv(String variableName) {
-    return environmentVariables.get(variableName);
+
+  public void setEnv(String name, String value) {
+    mockEnvVars.put(name, value);
+  }
+
+  @Override
+  public String getEnv(String Name) {
+    return mockEnvVars.get(Name);
   }
 }

--- a/hadoop-common-project/hadoop-common/src/test/java/io/hops/security/TestHopsX509Authenticator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/io/hops/security/TestHopsX509Authenticator.java
@@ -88,13 +88,13 @@ public class TestHopsX509Authenticator {
     authenticator.authenticateConnection(ugi, clientCertificate, remoteAddress);
   }
   
-  // In Hops super user's X.509 CN contains the FQDN/hostname of the machine
+  // In Hops super user's X.509 CN contains the FQDN/hostname of the machine and L her username
   @Test
   public void TestAuthenticatedSuperUser() throws Exception {
     InetAddress remoteAddress = InetAddress.getLocalHost();
     String o = "application_id";
     X509Certificate clientCertificate = generateX509Certificate("CN=" + remoteAddress.getCanonicalHostName()
-      + ", O=" + o);
+      + ", O=" + o + ", L=alice");
     UserGroupInformation ugi = UserGroupInformation.createRemoteUser("alice");
     HopsX509Authenticator authenticator = authFactory.getAuthenticator();
     authenticator.authenticateConnection(ugi, clientCertificate, remoteAddress);
@@ -104,17 +104,28 @@ public class TestHopsX509Authenticator {
   @Test
   public void TestNotAuthenticatedSuperUser() throws Exception {
     InetAddress remoteAddress = InetAddress.getLocalHost();
-    X509Certificate clientCertificate = generateX509Certificate("CN=i_hope_this_is_not_routable");
+    X509Certificate clientCertificate = generateX509Certificate("CN=i_hope_this_is_not_routable,L=real_super");
     UserGroupInformation ugi = UserGroupInformation.createRemoteUser("chuck");
     HopsX509Authenticator authenticator = authFactory.getAuthenticator();
     expectedException.expect(HopsX509AuthenticationException.class);
     authenticator.authenticateConnection(ugi, clientCertificate, remoteAddress);
   }
-  
+
+  @Test
+  public void TestNotAuthenticatedSuperUserWithResolvableCN() throws Exception {
+    InetAddress remoteAddress = InetAddress.getLocalHost();
+    X509Certificate clientCertificate = generateX509Certificate("CN=" + remoteAddress.getCanonicalHostName() +
+            ", L=real_super");
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser("chuck");
+    HopsX509Authenticator authenticator = authFactory.getAuthenticator();
+    expectedException.expect(HopsX509AuthenticationException.class);
+    authenticator.authenticateConnection(ugi, clientCertificate, remoteAddress);
+  }
   @Test
   public void TestFQDNCache() throws Exception {
     InetAddress remoteAddress = InetAddress.getLocalHost();
-    X509Certificate clientCertificate = generateX509Certificate("CN=" + remoteAddress.getCanonicalHostName());
+    X509Certificate clientCertificate = generateX509Certificate("CN=" + remoteAddress.getCanonicalHostName()
+      + ",L=alice");
     UserGroupInformation ugi = UserGroupInformation.createRemoteUser("alice");
     CustomHopsX509Authenticator authenticator = new CustomHopsX509Authenticator(conf);
     authenticator.authenticateConnection(ugi, clientCertificate, remoteAddress);

--- a/hadoop-common-project/hadoop-common/src/test/java/io/hops/security/TestSuperuserKeystoresLoader.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/io/hops/security/TestSuperuserKeystoresLoader.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.security;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.ssl.X509SecurityMaterial;
+import org.apache.hadoop.util.envVars.EnvironmentVariables;
+import org.apache.hadoop.util.envVars.EnvironmentVariablesFactory;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import java.nio.file.Paths;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestSuperuserKeystoresLoader {
+  private static final String USER = "alice";
+  
+  @After
+  public void afterEach() {
+    EnvironmentVariablesFactory.setInstance(null);
+  }
+  
+  @Test
+  public void testLoadEnvironmentVariable() throws Exception {
+    final String materialDirectory = "/tmp/secrets";
+    MockEnvironmentVariables envVars = new MockEnvironmentVariables();
+    envVars.setEnv(SuperuserKeystoresLoader.SUPER_MATERIAL_DIRECTORY_ENV_VARIABLE, materialDirectory);
+    EnvironmentVariablesFactory.setInstance(envVars);
+  
+    Configuration conf = new Configuration(false);
+    final SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(USER);
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        X509SecurityMaterial material = loader.loadSuperUserMaterial();
+        assertMaterialEquals(materialDirectory, loader, material);
+        return null;
+      }
+    });
+  }
+  
+  @Test
+  public void testLoadConfiguration() throws Exception {
+    final String materialDirectory = "/tmp/secure/bin";
+    Configuration conf = new Configuration(false);
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, materialDirectory);
+    final SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(USER);
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        X509SecurityMaterial material = loader.loadSuperUserMaterial();
+        assertMaterialEquals(materialDirectory, loader, material);
+        return null;
+      }
+    });
+  }
+  
+  @Test
+  public void testLoadFromHome() throws Exception {
+    final String materialDirectory = Paths.get(System.getProperty("user.home"),
+        SuperuserKeystoresLoader.SUPER_MATERIAL_HOME_SUBDIRECTORY).toString();
+    Configuration conf = new Configuration(false);
+    final SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(USER);
+    ugi.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        X509SecurityMaterial material = loader.loadSuperUserMaterial();
+        assertMaterialEquals(materialDirectory, loader, material);
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testLoadFromHomeWithVariable() throws Exception {
+    final String materialDirectory = "${HOME}/.hops_tls";
+    final String expectedDirectory = Paths.get(System.getProperty("user.home"), ".hops_tls").toString();
+    Configuration conf = new Configuration(false);
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, materialDirectory);
+    final SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(USER);
+    ugi.doAs(new PrivilegedExceptionAction<Object>() {
+      @Override
+      public Object run() throws Exception {
+        X509SecurityMaterial material = loader.loadSuperUserMaterial();
+        assertMaterialEquals(expectedDirectory, loader, material);
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testLoadFromDirectoryWithUserVariable() throws Exception {
+    final String materialDirectory = "/some/directory/${USER}";
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(USER);
+    final String expectedDirectory = Paths.get("/some/directory", ugi.getUserName()).toString();
+    Configuration conf = new Configuration(false);
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, materialDirectory);
+    final SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    ugi.doAs(new PrivilegedExceptionAction<Object>() {
+      @Override
+      public Object run() throws Exception {
+        X509SecurityMaterial material = loader.loadSuperUserMaterial();
+        assertMaterialEquals(expectedDirectory, loader, material);
+        return null;
+      }
+    });
+  }
+  
+  private void assertMaterialEquals(final String materialDirectory, final SuperuserKeystoresLoader loader,
+      final X509SecurityMaterial material) {
+    assertEquals(Paths.get(materialDirectory).resolve(loader.getSuperKeystoreFilename(USER)),
+        material.getKeyStoreLocation());
+    assertEquals(Paths.get(materialDirectory).resolve(loader.getSuperTruststoreFilename(USER)),
+        material.getTrustStoreLocation());
+    assertEquals(Paths.get(materialDirectory).resolve(loader.getSuperMaterialPasswdFilename(USER)),
+        material.getPasswdLocation());
+  }
+  
+  private class MockEnvironmentVariables implements EnvironmentVariables {
+  
+    private final Map<String, String> envs;
+    
+    private MockEnvironmentVariables() {
+      envs = new HashMap<>();
+    }
+    
+    @Override
+    public String getEnv(String variableName) {
+      return envs.get(variableName);
+    }
+    
+    public void setEnv(String name, String value) {
+      envs.put(name, value);
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestHopsUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/TestHopsUtil.java
@@ -78,21 +78,6 @@ public class TestHopsUtil {
     File passwdFile = passwdFilePath.toFile();
     String password = "password";
     FileUtils.writeStringToFile(passwdFile, password);
-
-    String keyStorePasswordFileKey = FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_PASSWORDFILE_LOCATION_TPL_KEY);
-    expected.put(keyStorePasswordFileKey, systemConf.get(SSLFactory.LOCALIZED_PASSWD_FILE_PATH_KEY,
-        SSLFactory.DEFAULT_LOCALIZED_PASSWD_FILE_PATH));
-
-    String keyStorePasswordKey = FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_KEYSTORE_PASSWORD_TPL_KEY);
-    expected.put(keyStorePasswordKey, password);
-    systemConf.set(keyStorePasswordKey, password);
-    
-    String keyStoreKeyPasswordKey = FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_KEYSTORE_KEYPASSWORD_TPL_KEY);
-    expected.put(keyStoreKeyPasswordKey, password);
-    systemConf.set(keyStoreKeyPasswordKey, password);
     
     sslClientFile = Paths.get(CLASSPATH, "ssl-client.xml").toFile();
     Configuration sslClientConf = new Configuration(false);
@@ -110,11 +95,6 @@ public class TestHopsUtil {
     expected.put(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
         FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY), keyStoreReloadUnitValue);
     sslClientConf.set(keyStoreReloadUnitKey, keyStoreReloadUnitValue);
-    
-    String trustStorePasswordKey = FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY);
-    expected.put(trustStorePasswordKey, password);
-    systemConf.set(trustStorePasswordKey, password);
     
     String trustStoreReloadIntervalKey = FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.CLIENT,
         FileBasedKeyStoresFactory.SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY);
@@ -153,23 +133,6 @@ public class TestHopsUtil {
     Map<String, String> expected = new HashMap<>();
     expected.put(FileBasedKeyStoresFactory.resolvePropertyName(
         SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory
-            .SSL_KEYSTORE_LOCATION_TPL_KEY),
-        systemConf.get(SSLFactory.LOCALIZED_KEYSTORE_FILE_PATH_KEY, SSLFactory.DEFAULT_LOCALIZED_KEYSTORE_FILE_PATH));
-    expected.put(FileBasedKeyStoresFactory.resolvePropertyName(
-        SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory
-            .SSL_TRUSTSTORE_LOCATION_TPL_KEY),
-        systemConf.get(SSLFactory.LOCALIZED_TRUSTSTORE_FILE_PATH_KEY, SSLFactory.DEFAULT_LOCALIZED_TRUSTSTORE_FILE_PATH));
-    expected.put(FileBasedKeyStoresFactory.resolvePropertyName(
-        SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory
-            .SSL_KEYSTORE_PASSWORD_TPL_KEY), password);
-    expected.put(FileBasedKeyStoresFactory.resolvePropertyName(
-        SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory
-            .SSL_KEYSTORE_KEYPASSWORD_TPL_KEY), password);
-    expected.put(FileBasedKeyStoresFactory.resolvePropertyName(
-        SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory
-            .SSL_TRUSTSTORE_PASSWORD_TPL_KEY), password);
-    expected.put(FileBasedKeyStoresFactory.resolvePropertyName(
-        SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory
             .SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY),
         String.valueOf(FileBasedKeyStoresFactory.DEFAULT_SSL_KEYSTORE_RELOAD_INTERVAL));
     expected.put(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
@@ -180,9 +143,6 @@ public class TestHopsUtil {
             .SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY),
         String.valueOf(FileBasedKeyStoresFactory
             .DEFAULT_SSL_TRUSTSTORE_RELOAD_INTERVAL));
-    expected.put(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_PASSWORDFILE_LOCATION_TPL_KEY),
-        systemConf.get(SSLFactory.LOCALIZED_PASSWD_FILE_PATH_KEY, SSLFactory.DEFAULT_LOCALIZED_PASSWD_FILE_PATH));
 
     assertSSLConfValues(expected, sslConf);
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestCRLValidator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/TestCRLValidator.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.security.ssl;
 
+import io.hops.security.MockEnvironmentVariablesService;
+import io.hops.security.SuperuserKeystoresLoader;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -49,6 +51,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
+import java.security.PrivilegedExceptionAction;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -102,8 +105,12 @@ public class TestCRLValidator {
   
   @Test
   public void testServerWithCRLValid() throws Exception {
-    Path serverkeystore = Paths.get(BASE_DIR, "server.kstore.jks");
-    Path serverTruststore = Paths.get(BASE_DIR, "server.tstore.jks");
+    UserGroupInformation currentUGI = UserGroupInformation.getCurrentUser();
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path serverKeystore = Paths.get(BASE_DIR, loader.getSuperKeystoreFilename(currentUGI.getUserName()));
+    Path serverTruststore = Paths.get(BASE_DIR, loader.getSuperTruststoreFilename(currentUGI.getUserName()));
+    Path serverPasswd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    
     Path crlPath = Paths.get(BASE_DIR, "input.server.crl.pem");
     Path fetchedCrlPath = Paths.get(BASE_DIR, "server.crl.pem");
     
@@ -111,22 +118,21 @@ public class TestCRLValidator {
     Path clientKeystore = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.KEYSTORE_SUFFIX);
     Path clientTruststore = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.TRUSTSTORE_SUFFIX);
     Path clientPasswordLocation = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.PASSWD_FILE_SUFFIX);
-    Path sslServerConfPath = Paths.get(confDir, TestCRLValidator.class.getSimpleName() + ".ssl-server.xml");
     Server server = null;
     TestRpcBase.TestRpcService proxy = null;
     
     RpcTLSUtils.TLSSetup tlsSetup = new RpcTLSUtils.TLSSetup.Builder()
         .setKeyAlgorithm(keyAlgorithm)
         .setSignatureAlgorithm(signatureAlgorithm)
-        .setServerKstore(serverkeystore)
+        .setServerKstore(serverKeystore)
         .setServerTstore(serverTruststore)
         .setServerStorePassword(password)
+        .setServerStorePasswordLocation(serverPasswd)
         .setClientKstore(clientKeystore)
         .setClientTstore(clientTruststore)
         .setClientStorePassword(password)
         .setClientPasswordLocation(clientPasswordLocation)
         .setClientUserName(clientUsername)
-        .setSslServerConf(sslServerConfPath)
         .build();
     RpcTLSUtils.TestCryptoMaterial testCryptoMaterial = RpcTLSUtils.setupTLSMaterial(conf, tlsSetup,
         TestCRLValidator.class);
@@ -183,8 +189,12 @@ public class TestCRLValidator {
   
   @Test
   public void testServerWithEnabledButMissingCRL() throws Exception {
-    Path serverkeystore = Paths.get(BASE_DIR, "server.kstore.jks");
-    Path serverTruststore = Paths.get(BASE_DIR, "server.tstore.jks");
+    UserGroupInformation currentUGI = UserGroupInformation.getCurrentUser();
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path serverKeystore = Paths.get(BASE_DIR, loader.getSuperKeystoreFilename(currentUGI.getUserName()));
+    Path serverTruststore = Paths.get(BASE_DIR, loader.getSuperTruststoreFilename(currentUGI.getUserName()));
+    Path serverPasswd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    
     Path crlPath = Paths.get(BASE_DIR, "input.server.crl.pem");
     Path fetchedCrlPath = Paths.get(BASE_DIR, "server.crl.pem");
   
@@ -192,7 +202,6 @@ public class TestCRLValidator {
     Path clientKeystore = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.KEYSTORE_SUFFIX);
     Path clientTruststore = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.TRUSTSTORE_SUFFIX);
     Path clientPasswordLocation = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.PASSWD_FILE_SUFFIX);
-    Path sslServerConfPath = Paths.get(confDir, TestCRLValidator.class.getSimpleName() + ".ssl-server.xml");
     
     Server server = null;
     TestRpcBase.TestRpcService proxy = null;
@@ -200,15 +209,15 @@ public class TestCRLValidator {
     RpcTLSUtils.TLSSetup tlsSetup = new RpcTLSUtils.TLSSetup.Builder()
         .setKeyAlgorithm(keyAlgorithm)
         .setSignatureAlgorithm(signatureAlgorithm)
-        .setServerKstore(serverkeystore)
+        .setServerKstore(serverKeystore)
         .setServerTstore(serverTruststore)
         .setServerStorePassword(password)
+        .setServerStorePasswordLocation(serverPasswd)
         .setClientKstore(clientKeystore)
         .setClientTstore(clientTruststore)
         .setClientStorePassword(password)
         .setClientPasswordLocation(clientPasswordLocation)
         .setClientUserName(clientUsername)
-        .setSslServerConf(sslServerConfPath)
         .build();
     RpcTLSUtils.TestCryptoMaterial testCryptoMaterial = RpcTLSUtils.setupTLSMaterial(conf, tlsSetup,
         TestCRLValidator.class);
@@ -247,8 +256,12 @@ public class TestCRLValidator {
   
   @Test
   public void testServerWithCRLInvalid() throws Exception {
-    Path serverkeystore = Paths.get(BASE_DIR, "server.kstore.jks");
-    Path serverTruststore = Paths.get(BASE_DIR, "server.tstore.jks");
+    UserGroupInformation currentUGI = UserGroupInformation.getCurrentUser();
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path serverKeystore = Paths.get(BASE_DIR, loader.getSuperKeystoreFilename(currentUGI.getUserName()));
+    Path serverTruststore = Paths.get(BASE_DIR, loader.getSuperTruststoreFilename(currentUGI.getUserName()));
+    Path serverPasswd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    
     Path crlPath = Paths.get(BASE_DIR, "input.server.crl.pem");
     Path fetchedCrlPath = Paths.get(BASE_DIR, "server.crl.pem");
     
@@ -256,22 +269,20 @@ public class TestCRLValidator {
     Path clientKeystore = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.KEYSTORE_SUFFIX);
     Path clientTruststore = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.TRUSTSTORE_SUFFIX);
     Path clientPasswordLocation = Paths.get(BASE_DIR, clientUsername + HopsSSLSocketFactory.PASSWD_FILE_SUFFIX);
-    Path sslServerConfPath = Paths.get(confDir, TestCRLValidator.class.getSimpleName() + ".ssl-server.xml");
     Server server = null;
-    TestRpcBase.TestRpcService proxy = null;
   
     RpcTLSUtils.TLSSetup tlsSetup = new RpcTLSUtils.TLSSetup.Builder()
         .setKeyAlgorithm(keyAlgorithm)
         .setSignatureAlgorithm(signatureAlgorithm)
-        .setServerKstore(serverkeystore)
+        .setServerKstore(serverKeystore)
         .setServerTstore(serverTruststore)
         .setServerStorePassword(password)
+        .setServerStorePasswordLocation(serverPasswd)
         .setClientKstore(clientKeystore)
         .setClientTstore(clientTruststore)
         .setClientStorePassword(password)
         .setClientPasswordLocation(clientPasswordLocation)
         .setClientUserName(clientUsername)
-        .setSslServerConf(sslServerConfPath)
         .build();
     RpcTLSUtils.TestCryptoMaterial testCryptoMaterial = RpcTLSUtils.setupTLSMaterial(conf, tlsSetup,
         TestCRLValidator.class);
@@ -356,12 +367,17 @@ public class TestCRLValidator {
   
   @Test
   public void testValidator() throws Exception {
-    Path caTruststore = Paths.get(BASE_DIR, "ca.truststore.jks");
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path caTruststore = Paths.get(BASE_DIR, loader.getSuperTruststoreFilename(ugi.getUserName()));
+    Path passwdLocation = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(ugi.getUserName()));
+    FileUtils.writeStringToFile(passwdLocation.toFile(), password);
+    
     Path crlPath = Paths.get(BASE_DIR, "crl.pem");
     
     // Generate CA keypair
     KeyPair cakeyPair = KeyStoreTestUtil.generateKeyPair(keyAlgorithm);
-    X509Certificate caCert = KeyStoreTestUtil.generateCertificate("CN=rootCA", cakeyPair, 60, signatureAlgorithm);
+    X509Certificate caCert = KeyStoreTestUtil.generateCertificate("CN=rootCA", cakeyPair, 60, signatureAlgorithm, true);
     
     // Generate CA truststore
     KeyStoreTestUtil.createTrustStore(caTruststore.toString(), password, "rootca", caCert);
@@ -370,8 +386,6 @@ public class TestCRLValidator {
     KeyPair clientKeyPair = KeyStoreTestUtil.generateKeyPair(keyAlgorithm);
     X509Certificate clientCert = KeyStoreTestUtil.generateSignedCertificate("CN=client", clientKeyPair, 30,
         signatureAlgorithm, cakeyPair.getPrivate(), caCert);
-    /*X509Certificate clientCert = KeyStoreTestUtil.generateCertificate("CN=client", clientKeyPair, 30,
-        signatureAlgorithm);*/
 
     // Verify client certificate is signed by CA
     clientCert.verify(cakeyPair.getPublic());
@@ -381,10 +395,7 @@ public class TestCRLValidator {
     writeCRLToFile(crl, crlPath);
   
     // Validate should pass
-    conf.set(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY), caTruststore.toString());
-    conf.set(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY), password);
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
     conf.set(CommonConfigurationKeys.HOPS_CRL_OUTPUT_FILE_KEY, crlPath.toString());
   
     CRLValidator validator = CRLValidatorFactory.getInstance().getValidator(CRLValidatorFactory.TYPE.TESTING, conf,
@@ -411,21 +422,22 @@ public class TestCRLValidator {
   
   @Test
   public void testCRLValidatorFactory() throws Exception {
-    Path truststore = Paths.get(BASE_DIR, "truststore.jks");
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path truststore = Paths.get(BASE_DIR, loader.getSuperTruststoreFilename(ugi.getUserName()));
+    Path passwdLocation = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(ugi.getUserName()));
+    FileUtils.writeStringToFile(passwdLocation.toFile(), password);
     Path crlPath = Paths.get(BASE_DIR, "crl.pem");
     
     // Generate CA keypair
     KeyPair keyPair = KeyStoreTestUtil.generateKeyPair(keyAlgorithm);
-    X509Certificate cert = KeyStoreTestUtil.generateCertificate("CN=root", keyPair, 60, signatureAlgorithm);
+    X509Certificate cert = KeyStoreTestUtil.generateCertificate("CN=root", keyPair, 60, signatureAlgorithm, true);
     // Generate CA truststore
     KeyStoreTestUtil.createTrustStore(truststore.toString(), password, "root", cert);
     X509CRL crl = KeyStoreTestUtil.generateCRL(cert, keyPair.getPrivate(), signatureAlgorithm, null, null);
     writeCRLToFile(crl, crlPath);
-  
-    conf.set(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY), truststore.toString());
-    conf.set(FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-        FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY), password);
+    
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
     conf.set(CommonConfigurationKeys.HOPS_CRL_OUTPUT_FILE_KEY, crlPath.toString());
     
     
@@ -442,7 +454,47 @@ public class TestCRLValidator {
     Assert.assertEquals(testingValidator1, testingValidator2);
     Assert.assertNotEquals(normalValidator1, testingValidator1);
   }
-  
+
+  /**
+   * Special use-case where non-superusers start an RPC Server with CRLValidation. The material loaded
+   * is not the ones returned by SuperuserKeystoresLoader but they should be located by HopsSSLSocketFactory instead
+   * which goes through a number of tests - identify material for normal users.
+   */
+  @Test
+  public void testCRLValidatioFactoryNonSuperuser() throws Exception {
+    String username = "application__user";
+    Path keystore = Paths.get(BASE_DIR, SSLFactory.DEFAULT_LOCALIZED_KEYSTORE_FILE_PATH);
+    Path truststore = Paths.get(BASE_DIR, SSLFactory.DEFAULT_LOCALIZED_TRUSTSTORE_FILE_PATH);
+    Path passwdLocation = Paths.get(BASE_DIR, SSLFactory.DEFAULT_LOCALIZED_PASSWD_FILE_PATH);
+    FileUtils.writeStringToFile(passwdLocation.toFile(), password);
+    Path crlPath = Paths.get(BASE_DIR, "crl.pem");
+
+    // Generate CA keypair
+    KeyPair keyPair = KeyStoreTestUtil.generateKeyPair(keyAlgorithm);
+    X509Certificate cert = KeyStoreTestUtil.generateCertificate("CN=root", keyPair, 60, signatureAlgorithm, true);
+    // Any file would be enough here, we don't load it - just checking if file exists
+    KeyStoreTestUtil.createKeyStore(keystore.toString(), password, password, "root", keyPair.getPrivate(), cert);
+    // Generate CA truststore
+    KeyStoreTestUtil.createTrustStore(truststore.toString(), password, "root", cert);
+    X509CRL crl = KeyStoreTestUtil.generateCRL(cert, keyPair.getPrivate(), signatureAlgorithm, null, null);
+    writeCRLToFile(crl, crlPath);
+
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
+    conf.set(CommonConfigurationKeys.HOPS_CRL_OUTPUT_FILE_KEY, crlPath.toString());
+    MockEnvironmentVariablesService mockEnvService = new MockEnvironmentVariablesService();
+    mockEnvService.setEnv("PWD", BASE_DIR);
+    EnvironmentVariablesFactory.setInstance(mockEnvService);
+
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(username);
+    CRLValidator validator = ugi.doAs(new PrivilegedExceptionAction<CRLValidator>() {
+      @Override
+      public CRLValidator run() throws Exception {
+        return CRLValidatorFactory.getInstance().getValidator(CRLValidatorFactory.TYPE.NORMAL, conf, conf);
+      }
+    });
+    Assert.assertNotNull(validator);
+  }
+
   @Test
   public void testRetryActions() throws Exception {
     boolean exceptionThrown = false;

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java
@@ -28,11 +28,13 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
@@ -100,6 +102,10 @@ public class URLConnectionFactory {
     final SSLSocketFactory sf;
     final HostnameVerifier hv;
 
+    if (conf.getBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED,
+            CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT)) {
+      conf.set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
+    }
     factory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
     factory.init();
     sf = factory.createSSLSocketFactory();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java
@@ -45,6 +45,8 @@ import java.util.Random;
 import java.util.Set;
 
 
+import io.hops.security.HopsUtil;
+import io.hops.security.SuperuserKeystoresLoader;
 import com.logicalclocks.servicediscoverclient.Builder;
 import com.logicalclocks.servicediscoverclient.ServiceDiscoveryClient;
 import com.logicalclocks.servicediscoverclient.exceptions.ServiceDiscoveryException;
@@ -77,6 +79,9 @@ import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory;
+import org.apache.hadoop.security.ssl.SSLFactory;
+import org.apache.hadoop.security.ssl.X509SecurityMaterial;
 import org.apache.hadoop.util.ToolRunner;
 
 import javax.net.SocketFactory;
@@ -688,19 +693,54 @@ public class DFSUtil {
     return policy;
   }
 
+  public static HttpServer2.Builder loadSslConfToHttpServerBuilder(HttpServer2.Builder builder, Configuration sslConf) {
+    return loadSslConfToHttpServerBuilder(builder, sslConf, null);
+  }
+
   public static HttpServer2.Builder loadSslConfToHttpServerBuilder(HttpServer2.Builder builder,
-      Configuration sslConf) {
+      Configuration sslConf, Configuration systemConf) {
+    String keystoreLocation = sslConf.get(
+            FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
+                    FileBasedKeyStoresFactory.SSL_KEYSTORE_LOCATION_TPL_KEY), null);
+    builder.needsClientAuth(sslConf.getBoolean(DFS_CLIENT_HTTPS_NEED_AUTH_KEY, DFS_CLIENT_HTTPS_NEED_AUTH_DEFAULT));
+    if (keystoreLocation != null) {
+      // ssl-server.xml has been populated, load material from there
+      return loadFromSSLServerConf(builder, sslConf);
+    }
+    return loadFromSuperUserLoader(builder, sslConf, systemConf);
+  }
+
+  private static HttpServer2.Builder loadFromSSLServerConf(HttpServer2.Builder builder, Configuration sslConf) {
     return builder
-        .needsClientAuth(
-            sslConf.getBoolean(DFS_CLIENT_HTTPS_NEED_AUTH_KEY,
-                DFS_CLIENT_HTTPS_NEED_AUTH_DEFAULT))
-        .keyPassword(getPassword(sslConf, DFS_SERVER_HTTPS_KEYPASSWORD_KEY))
-        .keyStore(sslConf.get("ssl.server.keystore.location"),
-            getPassword(sslConf, DFS_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY),
-            sslConf.get("ssl.server.keystore.type", "jks"))
-        .trustStore(sslConf.get("ssl.server.truststore.location"),
-            getPassword(sslConf, DFS_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY),
-            sslConf.get("ssl.server.truststore.type", "jks"));
+            .keyPassword(getPassword(sslConf, DFS_SERVER_HTTPS_KEYPASSWORD_KEY))
+            .keyStore(sslConf.get("ssl.server.keystore.location"),
+                    getPassword(sslConf, DFS_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY),
+                    sslConf.get("ssl.server.keystore.type", "jks"))
+            .trustStore(sslConf.get("ssl.server.truststore.location"),
+                    getPassword(sslConf, DFS_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY),
+                    sslConf.get("ssl.server.truststore.type", "jks"));
+  }
+
+  private static HttpServer2.Builder loadFromSuperUserLoader(HttpServer2.Builder builder, Configuration sslConf,
+      Configuration systemConf) {
+    if (systemConf == null) {
+      throw new IllegalArgumentException("System configuration must not be null when loading x.509 material with" +
+              " SuperUserLoader");
+    }
+    try {
+      SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(systemConf);
+      X509SecurityMaterial material = loader.loadSuperUserMaterial();
+      String password = HopsUtil.readCryptoMaterialPassword(material.getPasswdLocation().toFile());
+      return builder
+              .keyPassword(password)
+              .keyStore(material.getKeyStoreLocation().toString(), password,
+                      sslConf.get("ssl.server.keystore.type", "jks"))
+              .trustStore(material.getTrustStoreLocation().toString(), password,
+                      sslConf.get("ssl.server.truststore.type", "jks"));
+    } catch (IOException ex) {
+      LOG.fatal("Could not system user x.509 material with SuperuserLoader", ex);
+      throw new RuntimeException(ex);
+    }
   }
 
   public static List<InetSocketAddress> getNameNodesServiceRpcAddresses(
@@ -1048,7 +1088,7 @@ public class DFSUtil {
 
     if (policy.isHttpsEnabled() && httpsAddr != null) {
       Configuration sslConf = loadSslConfiguration(conf);
-      loadSslConfToHttpServerBuilder(builder, sslConf);
+      loadSslConfToHttpServerBuilder(builder, sslConf, conf);
 
       if (httpsAddr.getPort() == 0) {
         builder.setFindPort(true);

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/web/DatanodeHttpServer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdfs.server.datanode.web;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import io.netty.bootstrap.ChannelFactory;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -33,6 +34,7 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.hdfs.server.datanode.DataNode;
@@ -108,6 +110,10 @@ public class DatanodeHttpServer implements Closeable {
     }
 
     if (policy.isHttpsEnabled()) {
+      if (conf.getBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED,
+              CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT)) {
+        conf.set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
+      }
       this.sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
       try {
         sslFactory.init();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSSSLServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSSSLServer.java
@@ -17,7 +17,6 @@ package org.apache.hadoop.hdfs;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileSystem;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/Fetcher.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/task/reduce/Fetcher.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import javax.crypto.SecretKey;
 import javax.net.ssl.HttpsURLConnection;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.JobConf;
@@ -171,6 +173,10 @@ class Fetcher<K,V> extends Thread {
       sslShuffle = job.getBoolean(MRConfig.SHUFFLE_SSL_ENABLED_KEY,
                                   MRConfig.SHUFFLE_SSL_ENABLED_DEFAULT);
       if (sslShuffle && sslFactory == null) {
+        if (job.getBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED,
+                CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT)) {
+          job.set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
+        }
         sslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, job);
         try {
           sslFactory.init();
@@ -325,7 +331,7 @@ class Fetcher<K,V> extends Thread {
     // Construct the url and connect
     URL url = getMapOutputURL(host, maps);
     DataInputStream input = null;
-    
+
     try {
       input = openShuffleUrl(host, remaining, url);
       if (input == null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleHandler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-shuffle/src/main/java/org/apache/hadoop/mapred/ShuffleHandler.java
@@ -54,7 +54,9 @@ import java.util.regex.Pattern;
 
 import javax.crypto.SecretKey;
 
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -799,6 +801,10 @@ public class ShuffleHandler extends AuxiliaryService {
       if (conf.getBoolean(MRConfig.SHUFFLE_SSL_ENABLED_KEY,
                           MRConfig.SHUFFLE_SSL_ENABLED_DEFAULT)) {
         LOG.info("Encrypted shuffle is enabled.");
+        if (conf.getBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED,
+                CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT)) {
+          conf.set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
+        }
         sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
         sslFactory.init();
       }
@@ -1355,7 +1361,7 @@ public class ShuffleHandler extends AuxiliaryService {
       }
     }
   }
-  
+
   static class AttemptPathInfo {
     // TODO Change this over to just store local dir indices, instead of the
     // entire path. Far more efficient.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/TopCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/main/java/org/apache/hadoop/yarn/client/cli/TopCLI.java
@@ -46,6 +46,7 @@ import javax.net.ssl.SSLSocketFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.hops.security.HopsFileBasedKeyStoresFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -56,6 +57,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
@@ -831,6 +833,10 @@ public class TopCLI extends YarnCLI {
     URLConnection connection;
     // If https is chosen, configures SSL client.
     if (YarnConfiguration.useHttps(getConf())) {
+      if (getConf().getBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED,
+              CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED_DEFAULT)) {
+        getConf().set(SSLFactory.KEYSTORES_FACTORY_CLASS_KEY, HopsFileBasedKeyStoresFactory.class.getCanonicalName());
+      }
       clientSslFactory = new SSLFactory(SSLFactory.Mode.CLIENT, getConf());
       clientSslFactory.init();
       SSLSocketFactory sslSocktFact = clientSslFactory.createSSLSocketFactory();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/BaseContainerManagerTest.java
@@ -559,7 +559,13 @@ public abstract class BaseContainerManagerTest {
     context.getContainerTokenSecretManager().setMasterKey(masterKey);
     context.getNMTokenSecretManager().setMasterKey(masterKey);
     if (context.isHopsTLSEnabled() || context.isJWTEnabled()) {
-      certificateLocalizationService = new CertificateLocalizationService(CertificateLocalizationService.ServiceType.NM);
+      certificateLocalizationService =
+              new CertificateLocalizationService(CertificateLocalizationService.ServiceType.NM){
+                @Override
+                public char[] readSupersuperPassword() throws IOException {
+                  return "password".toCharArray();
+                }
+              };
       certificateLocalizationService.init(conf);
       certificateLocalizationService.start();
       context.setCertificateLocalizationService(certificateLocalizationService);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/X509SecurityHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/security/X509SecurityHandler.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.yarn.server.resourcemanager.security;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.hops.security.HopsUtil;
+import io.hops.security.SuperuserKeystoresLoader;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,6 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory;
 import org.apache.hadoop.security.ssl.SSLFactory;
+import org.apache.hadoop.security.ssl.X509SecurityMaterial;
 import org.apache.hadoop.util.BackOff;
 import org.apache.hadoop.util.DateUtils;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -92,6 +95,7 @@ public class X509SecurityHandler
   private final RMAppSecurityManager rmAppSecurityManager;
   private final SecureRandom rng;
   private final EventHandler eventHandler;
+  private SuperuserKeystoresLoader superuserKeystoresLoader;
   
   private CertificateLocalizationService certificateLocalizationService;
   private RMAppSecurityActions rmAppSecurityActions;
@@ -154,6 +158,7 @@ public class X509SecurityHandler
     revocationUnitOfInterval = monitorIntervalUnit.getSecond();
   
     if (isHopsTLSEnabled()) {
+      superuserKeystoresLoader = new SuperuserKeystoresLoader(config);
       this.certificateLocalizationService = rmContext.getCertificateLocalizationService();
       rmAppSecurityActions = rmAppSecurityManager.getRmAppCertificateActions();
       keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM, SECURITY_PROVIDER);
@@ -312,23 +317,21 @@ public class X509SecurityHandler
     String sslConfName = conf.get(SSLFactory.SSL_SERVER_CONF_KEY, "ssl-server.xml");
     Configuration sslConf = new Configuration();
     sslConf.addResource(sslConfName);
-    String trustStoreLocation = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY));
-    String trustStorePassword = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY));
     String trustStoreType = sslConf.get(
-        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
-            FileBasedKeyStoresFactory.SSL_TRUSTSTORE_TYPE_TPL_KEY),
+        FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory.SSL_TRUSTSTORE_TYPE_TPL_KEY),
         FileBasedKeyStoresFactory.DEFAULT_KEYSTORE_TYPE);
     
-    KeyStore trustStore = KeyStore.getInstance(trustStoreType);
-    try (FileInputStream fis = new FileInputStream(trustStoreLocation)) {
-      trustStore.load(fis, trustStorePassword.toCharArray());
+    if (superuserKeystoresLoader == null) {
+      throw new GeneralSecurityException("Tried to load system truststore but SuperuserKeystoreLoader has not been " +
+          "initialized");
     }
-    
-    return trustStore;
+    X509SecurityMaterial x509Material = superuserKeystoresLoader.loadSuperUserMaterial();
+    String truststorePassword = HopsUtil.readCryptoMaterialPassword(x509Material.getPasswdLocation().toFile());
+    KeyStore truststore = KeyStore.getInstance(trustStoreType);
+    try (FileInputStream fis = new FileInputStream(x509Material.getTrustStoreLocation().toFile())) {
+      truststore.load(fis, truststorePassword.toCharArray());
+    }
+    return truststore;
   }
   
   @InterfaceAudience.Private

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRMWithCustomAMLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/MockRMWithCustomAMLauncher.java
@@ -49,7 +49,7 @@ public class MockRMWithCustomAMLauncher extends MockRM {
     super(conf);
     this.containerManager = containerManager;
   }
-  
+
   @Override
   protected ApplicationMasterLauncher createAMLauncher() {
     return new ApplicationMasterLauncher(getRMContext()) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestResourceTrackerService.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.yarn.server.resourcemanager;
 
+import io.hops.security.CertificateLocalizationService;
 import io.hops.util.DBUtility;
 import io.hops.util.RMStorageFactory;
 import io.hops.util.YarnAPIStorageFactory;
@@ -340,7 +341,17 @@ public class TestResourceTrackerService extends NodeLabelTestBase {
     conf.setBoolean(YarnConfiguration.RM_JWT_ENABLED, true);
     conf.set(YarnConfiguration.RM_JWT_VALIDITY_PERIOD, "20s");
     conf.set(YarnConfiguration.RM_JWT_EXPIRATION_LEEWAY, "4s");
-    rm = new MockRM(conf);
+    rm = new MockRM(conf){
+      @Override
+      protected CertificateLocalizationService createCertificateLocalizationService() {
+        return new CertificateLocalizationService(CertificateLocalizationService.ServiceType.RM) {
+          @Override
+          public char[] readSupersuperPassword() throws IOException {
+            return "password".toCharArray();
+          }
+        };
+      }
+    };
     rm.start();
     
     MockNM nm1 = rm.registerNode("localhost:1234", 5 * 1024);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestX509SecurityHandler.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/security/TestX509SecurityHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.yarn.server.resourcemanager.security;
 
 import io.hops.security.AbstractSecurityActions;
 import io.hops.security.HopsSecurityActionsFactory;
+import io.hops.security.SuperuserKeystoresLoader;
 import io.hops.util.DBUtility;
 import io.hops.util.RMStorageFactory;
 import io.hops.util.YarnAPIStorageFactory;
@@ -27,6 +28,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.SSLFactory;
@@ -75,6 +78,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -107,18 +111,17 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
       Paths.get("target", "test-dir").toString()),
       TestX509SecurityHandler.class.getSimpleName()).toString();
   private static final File BASE_DIR_FILE = new File(BASE_DIR);
-  private static String classPath;
   
   private static Configuration conf;
   private DrainDispatcher dispatcher;
   private RMContext rmContext;
-  private File sslServerFile;
+  private static UserGroupInformation currentUGI;
   
   @BeforeClass
   public static void beforeClass() throws Exception {
     Security.addProvider(new BouncyCastleProvider());
     BASE_DIR_FILE.mkdirs();
-    classPath = KeyStoreTestUtil.getClasspathDir(TestX509SecurityHandler.class);
+    currentUGI = UserGroupInformation.getCurrentUser();
   }
   
   @Before
@@ -135,21 +138,12 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
     rmContext = new RMContextImpl(dispatcher, null, null, null, null, null, null, null, null);
     dispatcher.init(conf);
     dispatcher.start();
-  
-    String sslConfFileName = TestX509SecurityHandler.class.getSimpleName() + ".ssl-server.xml";
-    sslServerFile = Paths.get(classPath, sslConfFileName).toFile();
-    Configuration sslServer = new Configuration(false);
-    KeyStoreTestUtil.saveConfig(sslServerFile, sslServer);
-    conf.set(SSLFactory.SSL_SERVER_CONF_KEY, sslConfFileName);
   }
   
   @After
   public void afterTest() throws Exception {
     if (dispatcher != null) {
       dispatcher.stop();
-    }
-    if (sslServerFile != null) {
-      sslServerFile.delete();
     }
   }
   
@@ -165,56 +159,46 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
   
   @Test
   public void testSuccessfulCertificateCreationTesting() throws Exception {
-    File testSpecificSSLServerFile = null;
-    try {
-      conf.set(YarnConfiguration.HOPS_RM_SECURITY_ACTOR_KEY,
-          "org.apache.hadoop.yarn.server.resourcemanager.security.TestingRMAppSecurityActions");
-      
-      RMAppSecurityActions testActor = (RMAppSecurityActions) HopsSecurityActionsFactory.getInstance().getActor(conf,
-          conf.get(YarnConfiguration.HOPS_RM_SECURITY_ACTOR_KEY, YarnConfiguration.HOPS_RM_SECURITY_ACTOR_DEFAULT));
-      String trustStore = Paths.get(BASE_DIR, "trustStore.jks").toString();
-      X509Certificate caCert = ((TestingRMAppSecurityActions) testActor).getCaCert();
-      String principal = caCert.getIssuerX500Principal().getName();
-      // Principal should be CN=RootCA
-      String alias = principal.split("=")[1];
-      String password = "password";
-  
-      String sslServer = TestX509SecurityHandler.class.getSimpleName() + "-testSuccessfulCertificateCreationTesting.ssl-server.xml";
-      testSpecificSSLServerFile = Paths.get(classPath, sslServer).toFile();
-  
-      conf.set(SSLFactory.SSL_SERVER_CONF_KEY, sslServer);
-  
-      createTrustStore(trustStore, password, alias, caCert);
-      Configuration sslServerConf = createSSLConfig("", "", "", trustStore, password, "");
-      saveConfig(testSpecificSSLServerFile.getAbsoluteFile(), sslServerConf);
-  
-      MockRMAppEventHandler eventHandler = new MockRMAppEventHandler(RMAppEventType.SECURITY_MATERIAL_GENERATED);
-      rmContext.getDispatcher().register(RMAppEventType.class, eventHandler);
-      
-      RMAppSecurityManager rmAppSecurityManager = new RMAppSecurityManager(rmContext);
-      X509SecurityHandler x509SecurityHandler = new MockX509SecurityHandler(rmContext, rmAppSecurityManager, true);
-      rmAppSecurityManager.registerRMAppSecurityHandler(x509SecurityHandler);
-      rmAppSecurityManager.init(conf);
-      rmAppSecurityManager.start();
-      ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
-      X509SecurityHandler.X509MaterialParameter x509Param =
-          new X509SecurityHandler.X509MaterialParameter(
-              appId,"Dorothy", 1);
-      RMAppSecurityMaterial securityMaterial = new RMAppSecurityMaterial();
-      securityMaterial.addMaterial(x509Param);
-      RMAppSecurityManagerEvent genSecurityMaterialEvent = new RMAppSecurityManagerEvent(appId,
-          securityMaterial, RMAppSecurityManagerEventType.GENERATE_SECURITY_MATERIAL);
-      
-      rmAppSecurityManager.handle(genSecurityMaterialEvent);
-  
-      dispatcher.await();
-      eventHandler.verifyEvent();
-      rmAppSecurityManager.stop();
-    } finally {
-      if (testSpecificSSLServerFile != null) {
-        testSpecificSSLServerFile.delete();
-      }
-    }
+    conf.set(YarnConfiguration.HOPS_RM_SECURITY_ACTOR_KEY,
+        "org.apache.hadoop.yarn.server.resourcemanager.security.TestingRMAppSecurityActions");
+    
+    RMAppSecurityActions testActor = (RMAppSecurityActions) HopsSecurityActionsFactory.getInstance().getActor(conf,
+        conf.get(YarnConfiguration.HOPS_RM_SECURITY_ACTOR_KEY, YarnConfiguration.HOPS_RM_SECURITY_ACTOR_DEFAULT));
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    String trustStore = Paths.get(BASE_DIR, loader.getSuperTruststoreFilename(currentUGI.getUserName())).toString();
+    X509Certificate caCert = ((TestingRMAppSecurityActions) testActor).getCaCert();
+    String principal = caCert.getIssuerX500Principal().getName();
+    // Principal should be CN=RootCA
+    String alias = principal.split("=")[1];
+    String password = "password";
+    Path passwd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    FileUtils.writeStringToFile(passwd.toFile(), password);
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
+    
+    createTrustStore(trustStore, password, alias, caCert);
+    
+    MockRMAppEventHandler eventHandler = new MockRMAppEventHandler(RMAppEventType.SECURITY_MATERIAL_GENERATED);
+    rmContext.getDispatcher().register(RMAppEventType.class, eventHandler);
+    
+    RMAppSecurityManager rmAppSecurityManager = new RMAppSecurityManager(rmContext);
+    X509SecurityHandler x509SecurityHandler = new MockX509SecurityHandler(rmContext, rmAppSecurityManager, true);
+    rmAppSecurityManager.registerRMAppSecurityHandler(x509SecurityHandler);
+    rmAppSecurityManager.init(conf);
+    rmAppSecurityManager.start();
+    ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
+    X509SecurityHandler.X509MaterialParameter x509Param =
+        new X509SecurityHandler.X509MaterialParameter(
+            appId,"Dorothy", 1);
+    RMAppSecurityMaterial securityMaterial = new RMAppSecurityMaterial();
+    securityMaterial.addMaterial(x509Param);
+    RMAppSecurityManagerEvent genSecurityMaterialEvent = new RMAppSecurityManagerEvent(appId,
+        securityMaterial, RMAppSecurityManagerEventType.GENERATE_SECURITY_MATERIAL);
+    
+    rmAppSecurityManager.handle(genSecurityMaterialEvent);
+    
+    dispatcher.await();
+    eventHandler.verifyEvent();
+    rmAppSecurityManager.stop();
   }
   
   @Test
@@ -348,7 +332,11 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
     conf.set(YarnConfiguration.RM_APP_CERTIFICATE_EXPIRATION_SAFETY_PERIOD, "40s");
     conf.set(YarnConfiguration.RM_APP_CERTIFICATE_REVOCATION_MONITOR_INTERVAL, "3s");
     conf.setBoolean(CommonConfigurationKeys.IPC_SERVER_SSL_ENABLED, true);
-    
+  
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path passwd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    FileUtils.writeStringToFile(passwd.toFile(), "password");
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
     MockRM rm = new MyMockRM(conf);
     rm.start();
   
@@ -395,6 +383,10 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
     conf.set(YarnConfiguration.RM_APP_CERTIFICATE_EXPIRATION_SAFETY_PERIOD, "45s");
     conf.setBoolean(CommonConfigurationKeys.IPC_SERVER_SSL_ENABLED, true);
     
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path passwd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    FileUtils.writeStringToFile(passwd.toFile(), "password");
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
     MockRM rm  = new MyMockRM(conf);
     rm.start();
   
@@ -516,7 +508,11 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
     conf.set(YarnConfiguration.RM_STORE, DBRMStateStore.class.getName());
     conf.set(YarnConfiguration.RM_APP_CERTIFICATE_EXPIRATION_SAFETY_PERIOD, "40s");
     conf.setBoolean(CommonConfigurationKeys.IPC_SERVER_SSL_ENABLED, true);
-    
+  
+    SuperuserKeystoresLoader loader = new SuperuserKeystoresLoader(conf);
+    Path passwd = Paths.get(BASE_DIR, loader.getSuperMaterialPasswdFilename(currentUGI.getUserName()));
+    FileUtils.writeStringToFile(passwd.toFile(), "password");
+    conf.set(CommonConfigurationKeysPublic.HOPS_TLS_SUPER_MATERIAL_DIRECTORY, BASE_DIR);
     MockRM rm = new MyMockRM2(conf);
     rm.start();
     MockNM nm1 = new MockNM("127.0.0.1:1234", 2 * 1024, rm.getResourceTrackerService());
@@ -697,58 +693,6 @@ public class TestX509SecurityHandler extends RMSecurityHandlersBaseTest {
       ks.store(out, password.toCharArray());
     } finally {
       out.close();
-    }
-  }
-  
-  private Configuration createSSLConfig(String keystore, String password, String keyPassword, String trustKS,
-      String trustPass, String excludeCiphers) {
-    SSLFactory.Mode mode = SSLFactory.Mode.SERVER;
-    String trustPassword = trustPass;
-    Configuration sslConf = new Configuration(false);
-    if (keystore != null) {
-      sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-          FileBasedKeyStoresFactory.SSL_KEYSTORE_LOCATION_TPL_KEY), keystore);
-    }
-    if (password != null) {
-      sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-          FileBasedKeyStoresFactory.SSL_KEYSTORE_PASSWORD_TPL_KEY), password);
-    }
-    if (keyPassword != null) {
-      sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-          FileBasedKeyStoresFactory.SSL_KEYSTORE_KEYPASSWORD_TPL_KEY),
-          keyPassword);
-    }
-    sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-        FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_INTERVAL_TPL_KEY), "1000");
-    sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-        FileBasedKeyStoresFactory.SSL_KEYSTORE_RELOAD_TIMEUNIT_TPL_KEY), "MILLISECONDS");
-    if (trustKS != null) {
-      sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-          FileBasedKeyStoresFactory.SSL_TRUSTSTORE_LOCATION_TPL_KEY), trustKS);
-    }
-    if (trustPassword != null) {
-      sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-          FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY),
-          trustPassword);
-    }
-    if(null != excludeCiphers && !excludeCiphers.isEmpty()) {
-      sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-          FileBasedKeyStoresFactory.SSL_EXCLUDE_CIPHER_LIST),
-          excludeCiphers);
-    }
-    sslConf.set(FileBasedKeyStoresFactory.resolvePropertyName(mode,
-        FileBasedKeyStoresFactory.SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY), "1000");
-    
-    return sslConf;
-  }
-  
-  private void saveConfig(File file, Configuration conf)
-      throws IOException {
-    Writer writer = new FileWriter(file);
-    try {
-      conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnSSLServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnSSLServer.java
@@ -19,7 +19,6 @@ import io.hops.security.HopsX509AuthenticationException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.ipc.RpcServerException;
 import org.apache.hadoop.net.HopsSSLSocketFactory;
 import org.apache.hadoop.security.ssl.HopsSSLTestUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
@@ -55,7 +54,6 @@ import javax.net.ssl.SSLException;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1551

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
Each system user has its own set of x.509 material. Hops will load the respective keystore and truststore for the user.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Keystores location is no longer available in ssl-server.xml and system user material are loaded from /srv/hops/super_crypto

* **Other information**:
Previous PR https://github.com/hopshadoop/hops/pull/785 is closed after we moved our code-base to Hadoop 3.2.x