### PR TITLE
Bump commons-compress from 1.4.1 to 1.19 in /hadoop-project

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/erasure_coding/TestUtil.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/io/hops/erasure_coding/TestUtil.java
@@ -19,7 +19,6 @@ import io.hops.metadata.hdfs.entity.EncodingPolicy;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.tukaani.xz.UnsupportedOptionsException;
 
 import java.io.IOException;
 import java.util.Random;

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -627,7 +627,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.4.1</version>
+        <version>1.19</version>
       </dependency>
       <dependency>
         <groupId>xmlenc</groupId>


### PR DESCRIPTION
Bumps commons-compress from 1.4.1 to 1.19.

Signed-off-by: dependabot[bot] <support@github.com>

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [ ] HOPS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit
- [ ] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: