### PR TITLE
[HOPS-1580] fix leader election using bind address for http

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -1404,12 +1404,29 @@ public class NameNode implements NameNodeStatusMXBean {
     }
 
     String httpAddress;
+    /*
+     * httpServer.getHttpAddress() return the bind address. If we use 0.0.0.0 to listen to all interfaces the leader
+     * election system will return 0.0.0.0 as the http address and the client will not be able to connect to the UI
+     * to mitigate this we retunr the address used by the RPC. This address will work because the http server is 
+     * listening on very interfaces
+     * */
+    
     if (DFSUtil.getHttpPolicy(conf).isHttpEnabled()) {
-      httpAddress = httpServer.getHttpAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpAddress()
-          .getPort() ;
+      if (httpServer.getHttpAddress().getAddress().getHostAddress().equals("0.0.0.0")) {
+        httpAddress = rpcServer.getRpcAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpAddress()
+            .getPort();
+      } else {
+        httpAddress = httpServer.getHttpAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpAddress()
+            .getPort();
+      }
     } else {
-      httpAddress = httpServer.getHttpsAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpsAddress()
-          .getPort() ;
+      if (httpServer.getHttpsAddress().getAddress().getHostAddress().equals("0.0.0.0")) {
+        httpAddress = rpcServer.getRpcAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpsAddress()
+            .getPort();
+      } else {
+        httpAddress = httpServer.getHttpsAddress().getAddress().getHostAddress() + ":" + httpServer.getHttpsAddress()
+            .getPort();
+      }
     }
     
     leaderElection =


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1580

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
use rpc host for the leader election http address if the bind address for the http server is `0.0.0.0`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: