### PR TITLE
[HOPSFS-48] HDFS-13730. BlockReaderRemote.sendReadResult throws NPE. …

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/BasicInetPeer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/BasicInetPeer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketAddress;
 import java.nio.channels.ReadableByteChannel;
 
 import org.apache.hadoop.net.unix.DomainSocket;
@@ -93,7 +94,8 @@ class BasicInetPeer implements Peer {
 
   @Override
   public String getRemoteAddressString() {
-    return socket.getRemoteSocketAddress().toString();
+    SocketAddress address = socket.getRemoteSocketAddress();
+    return address == null ? null : address.toString();
   }
 
   @Override

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/NioInetPeer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/net/NioInetPeer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketAddress;
 import java.nio.channels.ReadableByteChannel;
 
 import org.apache.hadoop.net.SocketInputStream;
@@ -96,7 +97,8 @@ class NioInetPeer implements Peer {
 
   @Override
   public String getRemoteAddressString() {
-    return socket.getRemoteSocketAddress().toString();
+    SocketAddress address = socket.getRemoteSocketAddress();
+    return address == null ? null : address.toString();
   }
 
   @Override


### PR DESCRIPTION
…Contributed by Yuanbo Liu.

(cherry picked from commit 62ad9885ea8c75c134de43a3a925c76b253658e1)

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [ ] HOPS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit
- [ ] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: