### PR TITLE
[HOPSFS-146] Implement SIMPLE RPC authentication method where the CN should just be resolvable instead of matching the incoming RPC IP address

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsX509Authenticator.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/io/hops/security/HopsX509Authenticator.java
@@ -41,7 +41,12 @@ public class HopsX509Authenticator {
   
   private final Configuration conf;
   private final Cache<String, Set<InetAddress>> trustedHostnames;
-  
+
+  public enum AUTH_MODE {
+    SIMPLE,
+    STRICT
+  }
+
   public HopsX509Authenticator(Configuration conf) {
     this.conf = conf;
     trustedHostnames = CacheBuilder.newBuilder()
@@ -166,6 +171,9 @@ public class HopsX509Authenticator {
 
   private boolean isTrustedConnectionInternal(InetAddress actualAddress, Set<InetAddress> expectedAddresses,
           String expectedUsername, String actualUsername) {
+    if (getAuthenticationMode().equals(AUTH_MODE.SIMPLE)) {
+      return true;
+    }
     if (expectedUsername == null && actualUsername == null) {
       return doesAddressMatch(expectedAddresses, actualAddress);
     }
@@ -188,6 +196,10 @@ public class HopsX509Authenticator {
       }
     }
     return false;
+  }
+
+  private AUTH_MODE getAuthenticationMode() {
+    return conf.getEnum(CommonConfigurationKeys.HOPS_RPC_AUTH_MODE, AUTH_MODE.STRICT);
   }
 
   private boolean doesUsernameMatch(String expected, String actual) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -476,6 +476,8 @@ public class CommonConfigurationKeysPublic {
   
   private static final String HOPS_TLS_PREFIX = HOPS_PREFIX + "tls.";
   public static final String HOPS_TLS_SUPER_MATERIAL_DIRECTORY = HOPS_TLS_PREFIX + "superuser-material-directory";
+
+  public static final String HOPS_RPC_AUTH_MODE = HOPS_TLS_PREFIX + "rpc-acl-auth-mode";
   
   /**
    * Certificate Revocation List fetcher class

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -3152,6 +3152,13 @@
   </property>
 
   <property>
+    <name>hops.tls.rpc-acl-auth-mode</name>
+    <value>STRICT</value>
+    <description>In STRICT authentication mode, the resolved IP address of the client CN certificate must
+      match the incoming RPC IP address. In SIMPLE mode, the CN should just be resolvable</description>
+  </property>
+
+  <property>
     <name>hops.crl.validation.enabled</name>
     <value>false</value>
     <description>Enable CRL validation when HopsTLS is enabled</description>


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopsworks.atlassian.net/browse/HOPSFS-146

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: